### PR TITLE
Fix test-network path in simple-go

### DIFF
--- a/samples/application/simple-go/main.go
+++ b/samples/application/simple-go/main.go
@@ -106,7 +106,7 @@ func main() {
 	userId := getEnvWithFallback("USER_ID", "User1")
 
 	// we use the mspPath and connections profil provided by the fabric-samples test network if not specified by the user
-	testNetworkPath := filepath.Join(fpcPath, "integration", "test-network", "fabric-samples", "test-network")
+	testNetworkPath := filepath.Join(fpcPath, "samples", "deployment", "test-network", "fabric-samples", "test-network")
 
 	// If not set we use the msp folder in the fabric-samples test network
 	mspPath := getEnvWithFallback("MSP_PATH", filepath.Join(
@@ -199,7 +199,7 @@ func main() {
 	contract := fpc.GetContract(network, ccID)
 
 	// Invoke FPC Chaincode
-	logger.Infof("--> Invoke FPC chaincode: ")
+	logger.Infof("--> Invoke FPC chaincode: %s", contract.Name())
 	result, err := contract.SubmitTransaction("myFunction", "arg1", "arg2", "arg3")
 	if err != nil {
 		logger.Fatalf("Failed to Submit transaction: %v", err)

--- a/samples/deployment/test-network/README.md
+++ b/samples/deployment/test-network/README.md
@@ -87,11 +87,14 @@ export TEST_CC_ID=echo
 make ercc-ecc-start
 ```
 
+You should see two instances of the FPC Echo chaincode and two instances of the FPC Enclave Registry chaincode running.
 The FPC Chaincode is now up and running, ready for processing invocations!
+Note that the containers are running in foreground in your terminal using docker-compose. You can close them by pressing Ctrl+C.
 
 ## Interact with the FPC Chaincode
 
 Now we show how to use the [FPC Client SDK](../../../client_sdk/go) to interact with the FPC Chaincode running on the test network.
+We continue with a new terminal to keep the FPC Chaincode running in the other terminal.
 
 The Fabric-Samples test network generates the connection profiles which are required by the FPC Client SDK to connect to
 the network. For example, you can find the connection profile for `org1` in

--- a/samples/deployment/test-network/update-connection.sh
+++ b/samples/deployment/test-network/update-connection.sh
@@ -89,3 +89,5 @@ for org in "${orgs[@]}"; do
   yq m -i "${CONNECTIONS_PATH}" "${tmp_dir}/peers.yaml"
   yq v "${CONNECTIONS_PATH}"
 done
+
+echo "Updated!"


### PR DESCRIPTION
- Updating credentials path pointing to
`$FPC_PATH/samples/deployment/test-network`.
- Minor updates on test-network README.
- Adding output to update-contection.sh to tell the user that something
happend.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #578 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
