### PR TITLE
Add hybrid request encryption

### DIFF
--- a/common/enclave/cc_data.cpp
+++ b/common/enclave/cc_data.cpp
@@ -249,24 +249,15 @@ err:
     return false;
 }
 
-bool cc_data::decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const
+// decrypts a key transport message using asymmetric encryption provided by pdo::crypto with
+// the chaincode decryption key (cc_data.cc_decryption_key_)
+bool cc_data::decrypt_key_transport_message(
+    const ByteArray& encrypted_key_transport_message, ByteArray& key_transport_message) const
 {
     bool b;
-    CATCH(b, message = cc_decryption_key_.DecryptMessage(encrypted_message));
-    COND2LOGERR(!b, "message decryption failed");
-
-    return true;
-
-err:
-    return false;
-}
-
-bool cc_data::encrypt_message(
-    const ByteArray key, const ByteArray& message, ByteArray& encrypted_message) const
-{
-    bool b;
-    CATCH(b, encrypted_message = pdo::crypto::skenc::EncryptMessage(key, message));
-    COND2LOGERR(!b, "message encryption failed");
+    CATCH(b,
+        key_transport_message = cc_decryption_key_.DecryptMessage(encrypted_key_transport_message));
+    COND2LOGERR(!b, "key transport message decryption failed");
 
     return true;
 

--- a/common/enclave/cc_data.h
+++ b/common/enclave/cc_data.h
@@ -45,9 +45,8 @@ public:
     ByteArray get_state_encryption_key();
     std::string get_enclave_id();
     bool sign_message(const ByteArray& message, ByteArray& signature) const;
-    bool decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const;
-    bool encrypt_message(
-        const ByteArray key, const ByteArray& message, ByteArray& encrypted_message) const;
+    bool decrypt_key_transport_message(
+        const ByteArray& encrypted_key_transport_message, ByteArray& key_transport_message) const;
 };
 
 extern cc_data* g_cc_data;

--- a/common/enclave/cc_data.h
+++ b/common/enclave/cc_data.h
@@ -42,11 +42,13 @@ public:
         uint32_t credentials_max_size,
         uint32_t* credentials_size);
 
-    ByteArray get_state_encryption_key();
     std::string get_enclave_id();
     bool sign_message(const ByteArray& message, ByteArray& signature) const;
     bool decrypt_key_transport_message(
         const ByteArray& encrypted_key_transport_message, ByteArray& key_transport_message) const;
+    bool decrypt_state_value(const ByteArray& encrypted_value, ByteArray& value) const;
+    bool encrypt_state_value(const ByteArray& value, ByteArray& encrypted_value) const;
+    static int estimate_encrypted_state_value_length(const int value_len);
 };
 
 extern cc_data* g_cc_data;

--- a/ecc_enclave/enclave/crypto.cpp
+++ b/ecc_enclave/enclave/crypto.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "crypto.h"
-
+#include "error.h"
+#include "logging.h"
+#include "pdo/common/crypto/crypto.h"
 #include "sgx_trts.h"
 
 int get_random_bytes(uint8_t* buffer, size_t length)
@@ -19,4 +21,47 @@ int get_random_bytes(uint8_t* buffer, size_t length)
     /* WARNING WARNING WARNING */
     /* WARNING WARNING WARNING */
     return sgx_read_rand(buffer, length);
+}
+
+bool validate_key_length(const ByteArray key)
+{
+    return key.size() == pdo::crypto::constants::SYM_KEY_LEN;
+}
+
+bool decrypt_message(const ByteArray key, const ByteArray& encrypted_message, ByteArray& message)
+{
+    bool b;
+    COND2LOGERR(!validate_key_length(key), "invalid decryption key length");
+    CATCH(b, message = pdo::crypto::skenc::DecryptMessage(key, encrypted_message));
+    COND2LOGERR(!b, "message decryption failed");
+
+    return true;
+
+err:
+    return false;
+}
+
+bool encrypt_message(const ByteArray key, const ByteArray& message, ByteArray& encrypted_message)
+{
+    bool b;
+    COND2LOGERR(!validate_key_length(key), "invalid encryption key length");
+    CATCH(b, encrypted_message = pdo::crypto::skenc::EncryptMessage(key, message));
+    COND2LOGERR(!b, "message encryption failed");
+
+    return true;
+
+err:
+    return false;
+}
+
+bool compute_message_hash(const ByteArray message, ByteArray& message_hash)
+{
+    bool b;
+    CATCH(b, message_hash = pdo::crypto::ComputeMessageHash(message););
+    COND2LOGERR(!b, "computing message hash failed");
+
+    return true;
+
+err:
+    return false;
 }

--- a/ecc_enclave/enclave/crypto.h
+++ b/ecc_enclave/enclave/crypto.h
@@ -7,6 +7,17 @@
 
 #pragma once
 
+#include <vector>
 #include "fpc-types.h"
 
+typedef std::vector<uint8_t> ByteArray;
+
 int get_random_bytes(uint8_t* buffer, size_t length);
+
+bool validate_key_length(const ByteArray key);
+
+bool decrypt_message(const ByteArray key, const ByteArray& encrypted_message, ByteArray& message);
+
+bool encrypt_message(const ByteArray key, const ByteArray& message, ByteArray& encrypted_message);
+
+bool compute_message_hash(const ByteArray message, ByteArray& message_hash);

--- a/integration/client_sdk/go/stress_test/stress_test.go
+++ b/integration/client_sdk/go/stress_test/stress_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package stress_test_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	fpc "github.com/hyperledger/fabric-private-chaincode/client_sdk/go/pkg/gateway"
+	"github.com/hyperledger/fabric-private-chaincode/integration/client_sdk/go/utils"
+	testutils "github.com/hyperledger/fabric-private-chaincode/integration/client_sdk/go/utils"
+	"github.com/hyperledger/fabric-sdk-go/pkg/gateway"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestStress(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Chaincode Suite")
+}
+
+var (
+	network      *gateway.Network
+	echoContract fpc.Contract
+)
+
+var _ = BeforeSuite(func() {
+	ccID := "kv-test"
+	ccPath := filepath.Join(utils.FPCPath, "samples", "chaincode", ccID, "_build", "lib")
+
+	// setup stress test chaincode(s) (install, approve, commit)
+	err := testutils.Setup(ccID, ccPath, true)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	// get network
+	network, err = testutils.SetupNetwork("mychannel")
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(network).ShouldNot(BeNil())
+
+	// Get FPC Contract
+	echoContract = fpc.GetContract(network, ccID)
+	Expect(echoContract).ShouldNot(BeNil())
+})
+
+var _ = Describe("Stress tests", func() {
+	Context("Different payload sizes", func() {
+		When("submitting less than MAX_ARGUMENT_SIZE", func() {
+			It("should succeed", func() {
+				sizes := []int{1, 10, 100, 1000, 10000}
+				for _, size := range sizes {
+					fmt.Printf("Size = %d\n", size)
+
+					payload := make([]byte, size)
+					n, err := rand.Read(payload)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(n).Should(Equal(size))
+
+					key := "some-key"
+					value := base64.StdEncoding.EncodeToString(payload)
+
+					res, err := echoContract.SubmitTransaction("put_state", key, value)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal([]byte("OK")))
+
+					res, err = echoContract.EvaluateTransaction("get_state", key)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal([]byte(value)))
+				}
+			})
+		})
+	})
+
+	// TODO more stress tests added here
+})

--- a/integration/stress_test.sh
+++ b/integration/stress_test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+FPC_PATH="${SCRIPTDIR}/.."
+FABRIC_SCRIPTDIR="${FPC_PATH}/fabric/bin/"
+
+: ${FABRIC_CFG_PATH:="${FPC_PATH}/integration/config"}
+
+. ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
+. ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
+TEST_NAME=TestStress
+CHAINCODES=(auction_test echo_test)
+CC_PATH=${FPC_PATH}/samples/chaincode/auction/_build/lib/
+CC_LANG=fpc-c
+CC_VER="$(cat ${CC_PATH}/mrenclave)"
+CC_SEQ="1"
+CC_EP="OR('SampleOrg.member')" # note that we use .member as NodeOUs is disabled with the crypto material used in the integration tests.
+
+run_test() {
+    # call sdk test
+    try cd client_sdk/go/stress_test && go test -v
+
+    # cleanup
+    rm -rf keystore wallet
+}
+
+# 1. prepare
+para
+say "Preparing ${TEST_NAME} Test ..."
+# - clean up relevant docker images
+docker_clean ${ERCC_ID}
+
+trap ledger_shutdown EXIT
+
+para
+say "Run ${TEST_NAME} test"
+
+say "- setup ledger"
+ledger_init
+
+say "- run test"
+run_test
+
+say "- shutdown ledger"
+ledger_shutdown
+
+para
+yell "${TEST_NAME} test PASSED"
+exit 0

--- a/internal/crypto/client_encryption_test.go
+++ b/internal/crypto/client_encryption_test.go
@@ -1,0 +1,153 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
+	"github.com/hyperledger/fabric-private-chaincode/internal/utils"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/test-go/testify/assert"
+)
+
+func TestNewEncryptionContext(t *testing.T) {
+	provider := &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return nil, fmt.Errorf("some error while fetching key")
+		},
+	}
+	expectedErrorMsg := "failed to get chaincode encryption key from ercc: some error while fetching key"
+	ctx, err := provider.NewEncryptionContext()
+	assert.Nil(t, ctx)
+	assert.Error(t, err, expectedErrorMsg)
+
+	provider = &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte("some invalid base64 encoded key"), nil
+		},
+	}
+	ctx, err = provider.NewEncryptionContext()
+	assert.Nil(t, ctx)
+	assert.Error(t, err)
+
+	provider = &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte(base64.StdEncoding.EncodeToString([]byte("some key"))), nil
+		},
+	}
+	ctx, err = provider.NewEncryptionContext()
+	assert.NotNil(t, ctx)
+	assert.NoError(t, err)
+}
+
+func TestConceal(t *testing.T) {
+	f := "some function"
+	args := []string{"some", "args"}
+
+	// test with some invalid request encryption key
+	ctxImpl := &EncryptionContextImpl{
+		requestEncryptionKey: []byte("invalid request encryption key"),
+	}
+	request, err := ctxImpl.Conceal(f, args)
+	assert.Empty(t, request)
+	assert.Error(t, err)
+
+	// test with some invalid request encryption key
+	symKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+	ctxImpl = &EncryptionContextImpl{
+		requestEncryptionKey:   symKey,
+		chaincodeEncryptionKey: []byte("invalid chaincode encryption key"),
+	}
+	request, err = ctxImpl.Conceal(f, args)
+	assert.Empty(t, request)
+	assert.Error(t, err)
+
+	// test with valid rsa key
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotNil(t, pubKey)
+	assert.NotNil(t, privKey)
+	assert.NoError(t, err)
+	provider := &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte(base64.StdEncoding.EncodeToString(pubKey)), nil
+		},
+	}
+	ctx, err := provider.NewEncryptionContext()
+	assert.NotNil(t, ctx)
+	assert.NoError(t, err)
+
+	// should succeed
+	request, err = ctx.Conceal(f, args)
+	assert.NotEmpty(t, request)
+	assert.NoError(t, err)
+
+	_, err = base64.StdEncoding.DecodeString(request)
+	assert.NoError(t, err)
+}
+
+func TestReveal(t *testing.T) {
+	msg := []byte("some response")
+
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotNil(t, pubKey)
+	assert.NotNil(t, privKey)
+	assert.NoError(t, err)
+
+	requestEncryptionKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+
+	responseEncryptionKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+
+	ctx := &EncryptionContextImpl{
+		requestEncryptionKey:   requestEncryptionKey,
+		responseEncryptionKey:  responseEncryptionKey,
+		chaincodeEncryptionKey: pubKey,
+	}
+
+	// test different invalid inputs
+	resp, err := ctx.Reveal(nil)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte("invalid input (not base64)"))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(base64.StdEncoding.EncodeToString([]byte("not a SignedChaincodeResponseMessage"))))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: []byte("some invalid response")})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// msg not encrypted
+	response := &protos.ChaincodeResponseMessage{EncryptedResponse: msg}
+	responseBytes := protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// msg not base64 encoded
+	encryptedMsg, err := EncryptMessage(responseEncryptionKey, msg)
+	response = &protos.ChaincodeResponseMessage{EncryptedResponse: encryptedMsg}
+	responseBytes = protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// should succeed
+	encryptedMsg, err = EncryptMessage(responseEncryptionKey, []byte(base64.StdEncoding.EncodeToString(msg)))
+	response = &protos.ChaincodeResponseMessage{EncryptedResponse: encryptedMsg}
+	responseBytes = protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Equal(t, resp, msg)
+	assert.NoError(t, err)
+}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"crypto/rand"
 	"fmt"
 )
 
@@ -20,8 +21,9 @@ import (
 // #include "pdo-crypto-c-wrapper.h"
 import "C"
 
+// NewRSAKeys generates a new public/private RSA key pair
+// The returned RSA keys created by the PDO crypto lib are 2048bit long and are PEM encoded
 func NewRSAKeys() (publicKey []byte, privateKey []byte, e error) {
-	//The RSA keys created by the PDO crypto lib are 2048bit long and PEM encoded
 	//Here we roughly estimate that they fit in 2KB
 	const estimatedPemRsaLen = 2048
 	const serializedPublicKeyLen = estimatedPemRsaLen
@@ -49,8 +51,9 @@ func NewRSAKeys() (publicKey []byte, privateKey []byte, e error) {
 	return C.GoBytes(serializedPublicKeyPtr, C.int(serializedPublicKeyActualLen)), C.GoBytes(serializedPrivateKeyPtr, C.int(serializedPrivateKeyActualLen)), nil
 }
 
+// NewECDSAKeys generates a new public/private ECDSA key pair
+// The returned ECDSA keys are created by the PDO crypto lib and are PEM encoded
 func NewECDSAKeys() (publicKey []byte, privateKey []byte, e error) {
-	//The ECDSA keys created by the PDO crypto lib are PEM encoded
 	//Here we roughly estimate that they fit in 2KB
 	const estimatedPemEcdsaLen = 2048
 	const serializedPublicKeyLen = estimatedPemEcdsaLen
@@ -78,6 +81,44 @@ func NewECDSAKeys() (publicKey []byte, privateKey []byte, e error) {
 	return C.GoBytes(serializedPublicKeyPtr, C.int(serializedPublicKeyActualLen)), C.GoBytes(serializedPrivateKeyPtr, C.int(serializedPrivateKeyActualLen)), nil
 }
 
+// NewSymmetricKey generates a new symmetric key with the specified key length is required by the pdo crypto library
+func NewSymmetricKey() ([]byte, error) {
+	keyLength := C.SYM_KEY_LEN
+	key := make([]byte, keyLength)
+	n, err := rand.Read(key)
+	if n != len(key) || err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func VerifyMessage(publicKey []byte, message []byte, signature []byte) error {
+
+	publicKeyPtr := C.CBytes(publicKey)
+	defer C.free(publicKeyPtr)
+
+	messagePtr := C.CBytes(message)
+	defer C.free(messagePtr)
+
+	signaturePtr := C.CBytes(signature)
+	defer C.free(signaturePtr)
+
+	ret := C.verify_signature(
+		(*C.uint8_t)(publicKeyPtr),
+		(C.uint32_t)(len(publicKey)),
+		(*C.uint8_t)(messagePtr),
+		(C.uint32_t)(len(message)),
+		(*C.uint8_t)(signaturePtr),
+		(C.uint32_t)(len(signature)))
+
+	if ret == false {
+		return fmt.Errorf("verification failed")
+	}
+
+	return nil
+}
+
 func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) {
 	privateKeyPtr := C.CBytes(privateKey)
 	defer C.free(privateKeyPtr)
@@ -85,6 +126,7 @@ func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) 
 	messagePtr := C.CBytes(message)
 	defer C.free(messagePtr)
 
+	// TODO why are we using RSA_KEY_SIZE here? sign_message uses ecdsa
 	estimatedSignatureLen := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
 	signaturePtr := C.malloc(C.ulong(estimatedSignatureLen))
 	defer C.free(signaturePtr)
@@ -105,9 +147,9 @@ func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) 
 	return C.GoBytes(signaturePtr, C.int(signatureActualLen)), nil
 }
 
+// PkDecryptMessage is an RSA decryption performed with the pdo crypto library
+// Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
 func PkDecryptMessage(privateKey []byte, encryptedMessage []byte) (message []byte, e error) {
-	//This is an RSA dencryption performed with the pdo crypto library
-	//Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
 	//TODO-1: bump up the key length to 3072 to match NIST strength
 	//TODO-2: extend procedure for large input sizes (via hybrid encryption)
 
@@ -140,8 +182,77 @@ func PkDecryptMessage(privateKey []byte, encryptedMessage []byte) (message []byt
 	return C.GoBytes(decryptedMessagePtr, C.int(decryptedMessageActualLen)), nil
 }
 
+// PkEncryptMessage is an RSA encryption performed with the pdo crypto library
+// It requires an RSA public key of size RSA_KEY_SIZE as defined in pdo-crypto-c-wrapper.h
+// Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
+func PkEncryptMessage(publicKey []byte, message []byte) ([]byte, error) {
+	//TODO-1: bump up the key length to 3072 to match NIST strength
+
+	messagePtr := C.CBytes(message)
+	defer C.free(messagePtr)
+
+	publicKeyPtr := C.CBytes(publicKey)
+	defer C.free(publicKeyPtr)
+
+	//the max length of the message to be encrypted is dictated by the pdo crypto lib (see above)
+	if len(message) > int(C.RSA_PLAINTEXT_LEN) {
+		return nil, fmt.Errorf("message message too long for encryption")
+	}
+	//TODO add tests with different message lengths
+	encryptedMessageSize := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
+	encryptedMessagePtr := C.malloc(C.ulong(encryptedMessageSize))
+	defer C.free(encryptedMessagePtr)
+
+	encryptedMessageActualSize := C.uint32_t(0)
+
+	ret := C.pk_encrypt_message(
+		(*C.uint8_t)(publicKeyPtr),
+		C.uint32_t(len(publicKey)),
+		(*C.uint8_t)(messagePtr),
+		C.uint32_t(len(message)),
+		(*C.uint8_t)(encryptedMessagePtr),
+		C.uint32_t(encryptedMessageSize),
+		&encryptedMessageActualSize)
+	if ret == false {
+		return nil, fmt.Errorf("encryption failed")
+	}
+
+	return C.GoBytes(encryptedMessagePtr, C.int(encryptedMessageActualSize)), nil
+}
+
+// DecryptMessage is  symmetric-key encryption performed with the pdo crypto library
+func DecryptMessage(key []byte, encryptedMessage []byte) ([]byte, error) {
+
+	encryptedMessagePtr := C.CBytes(encryptedMessage)
+	defer C.free(encryptedMessagePtr)
+
+	keyPtr := C.CBytes(key)
+	defer C.free(keyPtr)
+
+	// the (decrypted) message size is estimated to be <= the encrypted message size
+	messageSize := len(encryptedMessage)
+	messagePtr := C.malloc(C.ulong(messageSize))
+	defer C.free(messagePtr)
+
+	messageActualSize := C.uint32_t(0)
+
+	ret := C.decrypt_message(
+		(*C.uint8_t)(keyPtr),
+		C.uint32_t(len(key)),
+		(*C.uint8_t)(encryptedMessagePtr),
+		C.uint32_t(len(encryptedMessage)),
+		(*C.uint8_t)(messagePtr),
+		C.uint32_t(messageSize),
+		&messageActualSize)
+	if ret == false {
+		return nil, fmt.Errorf("decryption failed")
+	}
+
+	return C.GoBytes(messagePtr, C.int(messageActualSize)), nil
+}
+
+//EncryptMessage is a symmetric-key encryption performed with the PDO crypto lib
 func EncryptMessage(key []byte, message []byte) (encryptedMessage []byte, e error) {
-	//This is a symmetric-key encryption performed with the PDO crypto lib
 
 	keyPtr := C.CBytes(key)
 	defer C.free(keyPtr)

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,143 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRSAKeys(t *testing.T) {
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, pubKey)
+	block, _ := pem.Decode(pubKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "RSA PUBLIC KEY", block.Type)
+	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	assert.NotNil(t, pub)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, privKey)
+	block, _ = pem.Decode(privKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "RSA PRIVATE KEY", block.Type)
+	pri, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	assert.NotNil(t, pri)
+	assert.NoError(t, err)
+}
+
+func TestNewECDSAKeys(t *testing.T) {
+	pubKey, privKey, err := NewECDSAKeys()
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, pubKey)
+	block, _ := pem.Decode(pubKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "PUBLIC KEY", block.Type)
+	// TODO check unsupported curve
+	//pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	//assert.NotNil(t, pub)
+	//assert.NoError(t, err)
+
+	assert.NotEmpty(t, privKey)
+	block, _ = pem.Decode(privKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "EC PRIVATE KEY", block.Type)
+	//pri, err := x509.ParseECPrivateKey(block.Bytes)
+	//assert.NotNil(t, pri)
+	//assert.NoError(t, err)
+}
+
+func TestNewSymmetricKey(t *testing.T) {
+	symKey, err := NewSymmetricKey()
+	assert.NotNil(t, symKey)
+	assert.NoError(t, err)
+}
+
+func TestSignature(t *testing.T) {
+	msg := []byte("some message")
+
+	pubKey, privKey, err := NewECDSAKeys()
+	assert.NotEmpty(t, pubKey)
+	assert.NotEmpty(t, privKey)
+	assert.NoError(t, err)
+
+	// fail with invalid key
+	sig, err := SignMessage([]byte("invalid key"), msg)
+	assert.Nil(t, sig)
+	assert.Error(t, err)
+
+	// should succeed
+	sig, err = SignMessage(privKey, msg)
+	assert.NotNil(t, sig)
+	assert.NoError(t, err)
+
+	err = VerifyMessage([]byte("invalid key"), msg, sig)
+	assert.Error(t, err)
+
+	err = VerifyMessage(pubKey, []byte("invalid msg"), sig)
+	assert.Error(t, err)
+
+	err = VerifyMessage(pubKey, msg, []byte("invalid sig"))
+	assert.Error(t, err)
+
+	// should succeed
+	err = VerifyMessage(pubKey, msg, sig)
+	assert.NoError(t, err)
+}
+
+func TestPkEncryption(t *testing.T) {
+	msg := []byte("some message")
+
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotEmpty(t, pubKey)
+	assert.NotEmpty(t, privKey)
+	assert.NoError(t, err)
+
+	cipher, err := PkEncryptMessage([]byte("invalid key"), msg)
+	assert.Nil(t, cipher)
+	assert.Error(t, err)
+
+	// should succeed
+	cipher, err = PkEncryptMessage(pubKey, msg)
+	assert.NotNil(t, cipher)
+	assert.NoError(t, err)
+
+	plain, err := PkDecryptMessage([]byte("invalid key"), cipher)
+	assert.Nil(t, plain)
+	assert.Error(t, err)
+
+	// should succeed
+	plain, err = PkDecryptMessage(privKey, cipher)
+	assert.Equal(t, plain, msg)
+	assert.NoError(t, err)
+}
+
+func TestSymEncryption(t *testing.T) {
+	msg := []byte("some message")
+
+	key, err := NewSymmetricKey()
+	assert.NotEmpty(t, key)
+	assert.NoError(t, err)
+
+	cipher, err := EncryptMessage([]byte("invalid key"), msg)
+	assert.Nil(t, cipher)
+	assert.Error(t, err)
+
+	// should succeed
+	cipher, err = EncryptMessage(key, msg)
+	assert.NotNil(t, cipher)
+	assert.NoError(t, err)
+
+	plain, err := DecryptMessage([]byte("invalid key"), cipher)
+	assert.Nil(t, plain)
+	assert.Error(t, err)
+
+	// should succeed
+	plain, err = DecryptMessage(key, cipher)
+	assert.Equal(t, plain, msg)
+	assert.NoError(t, err)
+}

--- a/protos/fpc.options
+++ b/protos/fpc.options
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-fpc.CleartextChaincodeRequest.return_encryption_key type:FT_POINTER
-
 fpc.ChaincodeRequestMessage.encrypted_request type:FT_POINTER
+fpc.ChaincodeRequestMessage.encrypted_key_transport_message type:FT_POINTER
+
+fpc.KeyTransportMessage.request_encryption_key type:FT_POINTER
+fpc.KeyTransportMessage.response_encryption_key type:FT_POINTER
 
 fpc.FPCKVSet.read_value_hashes type:FT_POINTER
 

--- a/protos/fpc/fpc.proto
+++ b/protos/fpc/fpc.proto
@@ -93,14 +93,22 @@ message InitEnclaveMessage {
 message CleartextChaincodeRequest {
     // the function and args to invoke
     protos.ChaincodeInput input = 1;
-
-    // key to (aes128-gcm) encrypt ChaincodeResponse
-    bytes return_encryption_key = 3;
 }
 
 message ChaincodeRequestMessage {
-    // an RSA-encryption of the serialization of CleartextChaincodeRequest with the chaincode encryption key
+    // an encryption (symmetric) of the serialization of CleartextChaincodeRequest with KeyTransportMessage.request_encryption_key
     bytes encrypted_request = 1;
+
+    // an encryption (asymmetric) of the serialization of request KeyTransportMessage with AttestedData.chaincode_ek
+    bytes encrypted_key_transport_message = 2;
+}
+
+message KeyTransportMessage {
+    // key to decrypt CleartextChaincodeRequest
+    bytes request_encryption_key = 1;
+
+    // key to encrypt CleartextChaincodeResponse
+    bytes response_encryption_key = 2;
 }
 
 message CleartextChaincodeResponse {
@@ -116,7 +124,7 @@ message FPCKVSet {
 }
 
 message ChaincodeResponseMessage {
-    // an aes128-gcm encryption of the serialization of CleartextChaincodeResponse
+    // an encryption (symmetric) of the serialization of CleartextChaincodeRequest with KeyTransportMessage.response_encryption_key
     bytes encrypted_response = 1;
 
     // R/W set (of cleartext keys but encrypted values)

--- a/samples/chaincode/kv-test/kv-test-cc.cpp
+++ b/samples/chaincode/kv-test/kv-test-cc.cpp
@@ -9,7 +9,7 @@
 #include <numeric>
 #include <vector>
 
-#define MAX_VALUE_SIZE (1 << 10)
+#define MAX_VALUE_SIZE (1 << 16)
 
 int invoke(
     uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
@@ -29,8 +29,15 @@ int invoke(
         }
         else
         {
-            put_state(params[0].c_str(), (uint8_t*)params[1].c_str(), params[1].length(), ctx);
-            result = std::string("OK");
+            if (params[1].length() > MAX_VALUE_SIZE)
+            {
+                result = std::string("max value size exceeded");
+            }
+            else
+            {
+                put_state(params[0].c_str(), (uint8_t*)params[1].c_str(), params[1].length(), ctx);
+                result = std::string("OK");
+            }
         }
     }
     else if (function_name == "get_state")


### PR DESCRIPTION
This introduces a hybrid encryption scheme for fpc requests. Before FPC
requests were encrypted using the chaincode encryption key using
RSA-based encryption. This had the limitation that the maximum payload
size was restricted to ~200bytes. They new scheme uses symmetric
encryption to encrypt the actual request and uses the chaincode
encryption key to encrypt the key used to encrypt the FPC request. The
encrypted request key is added to the request protos. Unit test for go
cryto package and support for mock_ecc were added.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
