### PR TITLE
Add hybrid request encryption

### DIFF
--- a/common/enclave/cc_data.cpp
+++ b/common/enclave/cc_data.cpp
@@ -249,10 +249,17 @@ err:
     return false;
 }
 
-bool cc_data::decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const
+bool cc_data::decrypt_cc_message(const ByteArray& encrypted_message_key,
+    const ByteArray& encrypted_message,
+    ByteArray& message) const
 {
     bool b;
-    CATCH(b, message = cc_decryption_key_.DecryptMessage(encrypted_message));
+    ByteArray message_key;
+
+    CATCH(b, message_key = cc_decryption_key_.DecryptMessage(encrypted_message_key));
+    COND2LOGERR(!b, "message key decryption failed");
+
+    CATCH(b, message = pdo::crypto::skenc::DecryptMessage(message_key, encrypted_message));
     COND2LOGERR(!b, "message decryption failed");
 
     return true;

--- a/common/enclave/cc_data.h
+++ b/common/enclave/cc_data.h
@@ -45,7 +45,9 @@ public:
     ByteArray get_state_encryption_key();
     std::string get_enclave_id();
     bool sign_message(const ByteArray& message, ByteArray& signature) const;
-    bool decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const;
+    bool decrypt_cc_message(const ByteArray& encrypted_message_key,
+        const ByteArray& encrypted_message,
+        ByteArray& message) const;
     bool encrypt_message(
         const ByteArray key, const ByteArray& message, ByteArray& encrypted_message) const;
 };

--- a/ecc_enclave/enclave/enclave.cpp
+++ b/ecc_enclave/enclave/enclave.cpp
@@ -60,9 +60,13 @@ int ecall_cc_invoke(const uint8_t* signed_proposal_proto_bytes,
         COND2LOGERR(cc_request_message.encrypted_request->size == 0, "zero size request");
 
         // decrypt request
-        b = g_cc_data->decrypt_cc_message(ByteArray(cc_request_message.encrypted_request->bytes,
-                                              cc_request_message.encrypted_request->bytes +
-                                                  cc_request_message.encrypted_request->size),
+        b = g_cc_data->decrypt_cc_message(
+            ByteArray(cc_request_message.encrypted_request_encryption_key->bytes,
+                cc_request_message.encrypted_request_encryption_key->bytes +
+                    cc_request_message.encrypted_request_encryption_key->size),
+            ByteArray(cc_request_message.encrypted_request->bytes,
+                cc_request_message.encrypted_request->bytes +
+                    cc_request_message.encrypted_request->size),
             clear_request);
         COND2ERR(!b);
 

--- a/internal/crypto/client_encryption.go
+++ b/internal/crypto/client_encryption.go
@@ -8,92 +8,17 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
-	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 
 	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
-
-	"fmt"
 )
 
-// #cgo CFLAGS: -I${SRCDIR}/../../common/crypto
-// #cgo LDFLAGS: -L${SRCDIR}/../../common/crypto/_build -L${SRCDIR}/../../common/logging/_build -Wl,--start-group -lupdo-crypto-adapt -lupdo-crypto -Wl,--end-group -lcrypto -lulogging -lstdc++ -lgcov
-// #include <stdio.h>
-// #include <stdlib.h>
-// #include <stdbool.h>
-// #include <stdint.h>
-// #include "pdo-crypto-c-wrapper.h"
-import "C"
-
 var logger = flogging.MustGetLogger("fpc-client-crypto")
-
-func keyGen() ([]byte, error) {
-	// the specified key length is required by the pdo crypto library
-	keyLength := C.SYM_KEY_LEN
-	key := make([]byte, keyLength)
-	n, err := rand.Read(key)
-	if n != len(key) || err != nil {
-		return nil, err
-	}
-
-	return key, nil
-}
-
-func encrypt(input []byte, encryptionKey []byte) ([]byte, error) {
-	//This is an RSA encryption performed with the pdo crypto library
-	//Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
-	//TODO-1: bump up the key length to 3072 to match NIST strength
-	//TODO-2: extend procedure for large input sizes (via hybrid encryption)
-
-	inputMessagePtr := C.CBytes(input)
-	defer C.free(inputMessagePtr)
-
-	encryptionKeyPtr := C.CBytes(encryptionKey)
-	defer C.free(encryptionKeyPtr)
-
-	//the max length of the message to be encrypted is dictated by the pdo crypto lib (see above)
-	if len(input) > int(C.RSA_PLAINTEXT_LEN) {
-		return nil, fmt.Errorf("input message too long for encryption")
-	}
-	//TODO add tests with different message lengths
-	encryptedMessageSize := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
-	encryptedMessagePtr := C.malloc(C.ulong(encryptedMessageSize))
-	defer C.free(encryptedMessagePtr)
-
-	encryptedMessageActualSize := C.uint32_t(0)
-
-	ret := C.pk_encrypt_message((*C.uint8_t)(encryptionKeyPtr), C.uint32_t(len(encryptionKey)), (*C.uint8_t)(inputMessagePtr), C.uint32_t(len(input)), (*C.uint8_t)(encryptedMessagePtr), C.uint32_t(encryptedMessageSize), &encryptedMessageActualSize)
-	if ret == false {
-		return nil, fmt.Errorf("encryption failed")
-	}
-
-	return C.GoBytes(encryptedMessagePtr, C.int(encryptedMessageActualSize)), nil
-}
-
-func decrypt(encryptedResponse []byte, resultEncryptionKey []byte) ([]byte, error) {
-	encryptedResponsePtr := C.CBytes(encryptedResponse)
-	defer C.free(encryptedResponsePtr)
-
-	resultEncryptionKeyPtr := C.CBytes(resultEncryptionKey)
-	defer C.free(resultEncryptionKeyPtr)
-
-	// the (decrypted) response size is estimated to be <= the encrypted response size
-	responseSize := len(encryptedResponse)
-	responsePtr := C.malloc(C.ulong(responseSize))
-	defer C.free(responsePtr)
-
-	responseActualSize := C.uint32_t(0)
-
-	ret := C.decrypt_message((*C.uint8_t)(resultEncryptionKeyPtr), C.uint32_t(len(resultEncryptionKey)), (*C.uint8_t)(encryptedResponsePtr), C.uint32_t(len(encryptedResponse)), (*C.uint8_t)(responsePtr), C.uint32_t(responseSize), &responseActualSize)
-	if ret == false {
-		return nil, fmt.Errorf("decryption failed")
-	}
-
-	return C.GoBytes(responsePtr, C.int(responseActualSize)), nil
-}
 
 type EncryptionProvider interface {
 	NewEncryptionContext() (EncryptionContext, error)
@@ -103,14 +28,20 @@ type EncryptionProviderImpl struct {
 	GetCcEncryptionKey func() ([]byte, error)
 }
 
-func (e EncryptionProviderImpl) NewEncryptionContext() (EncryptionContext, error) {
-	// pick response encryption key
-	resultEncryptionKey, err := keyGen()
+func (p EncryptionProviderImpl) NewEncryptionContext() (EncryptionContext, error) {
+	// pick request encryption key
+	requestEncryptionKey, err := NewSymmetricKey()
 	if err != nil {
 		return nil, err
 	}
 
-	ccEncryptionKey, err := e.GetCcEncryptionKey()
+	// pick response encryption key
+	resultEncryptionKey, err := NewSymmetricKey()
+	if err != nil {
+		return nil, err
+	}
+
+	ccEncryptionKey, err := p.GetCcEncryptionKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chaincode encryption key from ercc: %s", err.Error())
 	}
@@ -121,13 +52,14 @@ func (e EncryptionProviderImpl) NewEncryptionContext() (EncryptionContext, error
 	}
 
 	return &EncryptionContextImpl{
-		resultEncryptionKey:    resultEncryptionKey,
+		requestEncryptionKey:   requestEncryptionKey,
+		responseEncryptionKey:  resultEncryptionKey,
 		chaincodeEncryptionKey: ccEncryptionKey,
 	}, nil
 }
 
 // EncryptionContext defines the interface of an object responsible to encrypt the contents of a transaction invocation
-// and decrypt the corresponding response.
+// and DecryptMessage the corresponding response.
 // Conceal and Reveal must be called only once during the lifetime of an object that implements this interface. That is,
 // an EncryptionContext is only valid for a single transaction invocation.
 type EncryptionContext interface {
@@ -136,7 +68,8 @@ type EncryptionContext interface {
 }
 
 type EncryptionContextImpl struct {
-	resultEncryptionKey    []byte
+	requestEncryptionKey   []byte
+	responseEncryptionKey  []byte
 	chaincodeEncryptionKey []byte
 }
 
@@ -163,9 +96,9 @@ func (e *EncryptionContextImpl) Reveal(signedResponseBytesB64 []byte) ([]byte, e
 		return nil, err
 	}
 
-	clearResponseB64, err := decrypt(response.EncryptedResponse, e.resultEncryptionKey)
+	clearResponseB64, err := DecryptMessage(e.responseEncryptionKey, response.EncryptedResponse)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "decryption of response failed")
 	}
 	// TODO: above should eventually be a (protobuf but not base64 serialized) fabric response object,
 	//   rather than just the (base64-serialized) response string.
@@ -187,7 +120,7 @@ func (e *EncryptionContextImpl) Conceal(function string, args []string) (string,
 
 	ccRequest := &protos.CleartextChaincodeRequest{
 		Input:               &peer.ChaincodeInput{Args: bytes},
-		ReturnEncryptionKey: e.resultEncryptionKey,
+		ReturnEncryptionKey: e.responseEncryptionKey,
 	}
 	logger.Debugf("prepping chaincode params: %s", ccRequest)
 
@@ -196,13 +129,19 @@ func (e *EncryptionContextImpl) Conceal(function string, args []string) (string,
 		return "", err
 	}
 
-	encryptedParams, err := encrypt(serializedCcRequest, e.chaincodeEncryptionKey)
+	encryptedRequest, err := EncryptMessage(e.requestEncryptionKey, serializedCcRequest)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "encryption of request failed")
+	}
+
+	encryptedRequestEncryptionKey, err := PkEncryptMessage(e.chaincodeEncryptionKey, e.requestEncryptionKey)
+	if err != nil {
+		return "", errors.Wrap(err, "encryption of request encryption key failed")
 	}
 
 	encryptedCcRequest := &protos.ChaincodeRequestMessage{
-		EncryptedRequest: encryptedParams,
+		EncryptedRequest:              encryptedRequest,
+		EncryptedRequestEncryptionKey: encryptedRequestEncryptionKey,
 	}
 
 	serializedEncryptedCcRequest, err := proto.Marshal(encryptedCcRequest)

--- a/internal/crypto/client_encryption_test.go
+++ b/internal/crypto/client_encryption_test.go
@@ -1,0 +1,153 @@
+package crypto
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
+	"github.com/hyperledger/fabric-private-chaincode/internal/utils"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/test-go/testify/assert"
+)
+
+func TestNewEncryptionContext(t *testing.T) {
+	provider := &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return nil, fmt.Errorf("some error while fetching key")
+		},
+	}
+	expectedErrorMsg := "failed to get chaincode encryption key from ercc: some error while fetching key"
+	ctx, err := provider.NewEncryptionContext()
+	assert.Nil(t, ctx)
+	assert.Error(t, err, expectedErrorMsg)
+
+	provider = &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte("some invalid base64 encoded key"), nil
+		},
+	}
+	ctx, err = provider.NewEncryptionContext()
+	assert.Nil(t, ctx)
+	assert.Error(t, err)
+
+	provider = &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte(base64.StdEncoding.EncodeToString([]byte("some key"))), nil
+		},
+	}
+	ctx, err = provider.NewEncryptionContext()
+	assert.NotNil(t, ctx)
+	assert.NoError(t, err)
+}
+
+func TestConceal(t *testing.T) {
+	f := "some function"
+	args := []string{"some", "args"}
+
+	// test with some invalid request encryption key
+	ctxImpl := &EncryptionContextImpl{
+		requestEncryptionKey: []byte("invalid request encryption key"),
+	}
+	request, err := ctxImpl.Conceal(f, args)
+	assert.Empty(t, request)
+	assert.Error(t, err)
+
+	// test with some invalid request encryption key
+	symKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+	ctxImpl = &EncryptionContextImpl{
+		requestEncryptionKey:   symKey,
+		chaincodeEncryptionKey: []byte("invalid chaincode encryption key"),
+	}
+	request, err = ctxImpl.Conceal(f, args)
+	assert.Empty(t, request)
+	assert.Error(t, err)
+
+	// test with valid rsa key
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotNil(t, pubKey)
+	assert.NotNil(t, privKey)
+	assert.NoError(t, err)
+	provider := &EncryptionProviderImpl{
+		func() ([]byte, error) {
+			return []byte(base64.StdEncoding.EncodeToString(pubKey)), nil
+		},
+	}
+	ctx, err := provider.NewEncryptionContext()
+	assert.NotNil(t, ctx)
+	assert.NoError(t, err)
+
+	// should succeed
+	request, err = ctx.Conceal(f, args)
+	assert.NotEmpty(t, request)
+	assert.NoError(t, err)
+
+	_, err = base64.StdEncoding.DecodeString(request)
+	assert.NoError(t, err)
+}
+
+func TestReveal(t *testing.T) {
+	msg := []byte("some response")
+
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotNil(t, pubKey)
+	assert.NotNil(t, privKey)
+	assert.NoError(t, err)
+
+	requestEncryptionKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+
+	responseEncryptionKey, err := NewSymmetricKey()
+	assert.NoError(t, err)
+
+	ctx := &EncryptionContextImpl{
+		requestEncryptionKey:   requestEncryptionKey,
+		responseEncryptionKey:  responseEncryptionKey,
+		chaincodeEncryptionKey: pubKey,
+	}
+
+	// test different invalid inputs
+	resp, err := ctx.Reveal(nil)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte("invalid input (not base64)"))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(base64.StdEncoding.EncodeToString([]byte("not a SignedChaincodeResponseMessage"))))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: []byte("some invalid response")})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// msg not encrypted
+	response := &protos.ChaincodeResponseMessage{EncryptedResponse: msg}
+	responseBytes := protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// msg not base64 encoded
+	encryptedMsg, err := EncryptMessage(responseEncryptionKey, msg)
+	response = &protos.ChaincodeResponseMessage{EncryptedResponse: encryptedMsg}
+	responseBytes = protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// should succeed
+	encryptedMsg, err = EncryptMessage(responseEncryptionKey, []byte(base64.StdEncoding.EncodeToString(msg)))
+	response = &protos.ChaincodeResponseMessage{EncryptedResponse: encryptedMsg}
+	responseBytes = protoutil.MarshalOrPanic(response)
+	resp, err = ctx.Reveal([]byte(utils.MarshallProto(&protos.SignedChaincodeResponseMessage{ChaincodeResponseMessage: responseBytes})))
+	assert.Equal(t, resp, msg)
+	assert.NoError(t, err)
+}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 package crypto
 
 import (
+	"crypto/rand"
 	"fmt"
 )
 
@@ -20,8 +21,9 @@ import (
 // #include "pdo-crypto-c-wrapper.h"
 import "C"
 
+// NewRSAKeys generates a new public/private RSA key pair
+// The returned RSA keys created by the PDO crypto lib are 2048bit long and are PEM encoded
 func NewRSAKeys() (publicKey []byte, privateKey []byte, e error) {
-	//The RSA keys created by the PDO crypto lib are 2048bit long and PEM encoded
 	//Here we roughly estimate that they fit in 2KB
 	const estimatedPemRsaLen = 2048
 	const serializedPublicKeyLen = estimatedPemRsaLen
@@ -49,8 +51,9 @@ func NewRSAKeys() (publicKey []byte, privateKey []byte, e error) {
 	return C.GoBytes(serializedPublicKeyPtr, C.int(serializedPublicKeyActualLen)), C.GoBytes(serializedPrivateKeyPtr, C.int(serializedPrivateKeyActualLen)), nil
 }
 
+// NewECDSAKeys generates a new public/private ECDSA key pair
+// The returned ECDSA keys are created by the PDO crypto lib and are PEM encoded
 func NewECDSAKeys() (publicKey []byte, privateKey []byte, e error) {
-	//The ECDSA keys created by the PDO crypto lib are PEM encoded
 	//Here we roughly estimate that they fit in 2KB
 	const estimatedPemEcdsaLen = 2048
 	const serializedPublicKeyLen = estimatedPemEcdsaLen
@@ -78,6 +81,44 @@ func NewECDSAKeys() (publicKey []byte, privateKey []byte, e error) {
 	return C.GoBytes(serializedPublicKeyPtr, C.int(serializedPublicKeyActualLen)), C.GoBytes(serializedPrivateKeyPtr, C.int(serializedPrivateKeyActualLen)), nil
 }
 
+// NewSymmetricKey generates a new symmetric key with the specified key length is required by the pdo crypto library
+func NewSymmetricKey() ([]byte, error) {
+	keyLength := C.SYM_KEY_LEN
+	key := make([]byte, keyLength)
+	n, err := rand.Read(key)
+	if n != len(key) || err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func VerifyMessage(publicKey []byte, message []byte, signature []byte) error {
+
+	publicKeyPtr := C.CBytes(publicKey)
+	defer C.free(publicKeyPtr)
+
+	messagePtr := C.CBytes(message)
+	defer C.free(messagePtr)
+
+	signaturePtr := C.CBytes(signature)
+	defer C.free(signaturePtr)
+
+	ret := C.verify_signature(
+		(*C.uint8_t)(publicKeyPtr),
+		(C.uint32_t)(len(publicKey)),
+		(*C.uint8_t)(messagePtr),
+		(C.uint32_t)(len(message)),
+		(*C.uint8_t)(signaturePtr),
+		(C.uint32_t)(len(signature)))
+
+	if ret == false {
+		return fmt.Errorf("verification failed")
+	}
+
+	return nil
+}
+
 func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) {
 	privateKeyPtr := C.CBytes(privateKey)
 	defer C.free(privateKeyPtr)
@@ -85,6 +126,7 @@ func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) 
 	messagePtr := C.CBytes(message)
 	defer C.free(messagePtr)
 
+	// TODO why are we using RSA_KEY_SIZE here? sign_message uses ecdsa
 	estimatedSignatureLen := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
 	signaturePtr := C.malloc(C.ulong(estimatedSignatureLen))
 	defer C.free(signaturePtr)
@@ -105,40 +147,9 @@ func SignMessage(privateKey []byte, message []byte) (signature []byte, e error) 
 	return C.GoBytes(signaturePtr, C.int(signatureActualLen)), nil
 }
 
-func PkEncryptMessage(publicKey []byte, message []byte) (encryptedMessage []byte, e error) {
-	//This is an RSA encryption performed with the pdo crypto library
-	//Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
-	//TODO-1: bump up the key length to 3072 to match NIST strength
-	//TODO-2: extend procedure for large input sizes (via hybrid encryption)
-
-	inputMessagePtr := C.CBytes(message)
-	defer C.free(inputMessagePtr)
-
-	encryptionKeyPtr := C.CBytes(publicKey)
-	defer C.free(encryptionKeyPtr)
-
-	//the max length of the message to be encrypted is dictated by the pdo crypto lib (see above)
-	if len(message) > int(C.RSA_PLAINTEXT_LEN) {
-		return nil, fmt.Errorf("input message too long for encryption")
-	}
-	//TODO add tests with different message lengths
-	encryptedMessageSize := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
-	encryptedMessagePtr := C.malloc(C.ulong(encryptedMessageSize))
-	defer C.free(encryptedMessagePtr)
-
-	encryptedMessageActualSize := C.uint32_t(0)
-
-	ret := C.pk_encrypt_message((*C.uint8_t)(encryptionKeyPtr), C.uint32_t(len(publicKey)), (*C.uint8_t)(inputMessagePtr), C.uint32_t(len(message)), (*C.uint8_t)(encryptedMessagePtr), C.uint32_t(encryptedMessageSize), &encryptedMessageActualSize)
-	if ret == false {
-		return nil, fmt.Errorf("encryption failed")
-	}
-
-	return C.GoBytes(encryptedMessagePtr, C.int(encryptedMessageActualSize)), nil
-}
-
+// PkDecryptMessage is an RSA decryption performed with the pdo crypto library
+// Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
 func PkDecryptMessage(privateKey []byte, encryptedMessage []byte) (message []byte, e error) {
-	//This is an RSA dencryption performed with the pdo crypto library
-	//Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
 	//TODO-1: bump up the key length to 3072 to match NIST strength
 	//TODO-2: extend procedure for large input sizes (via hybrid encryption)
 
@@ -171,8 +182,77 @@ func PkDecryptMessage(privateKey []byte, encryptedMessage []byte) (message []byt
 	return C.GoBytes(decryptedMessagePtr, C.int(decryptedMessageActualLen)), nil
 }
 
+// PkEncryptMessage is an RSA encryption performed with the pdo crypto library
+// It requires an RSA public key of size RSA_KEY_SIZE as defined in pdo-crypto-c-wrapper.h
+// Importantly, the library uses 2048bit RSA keys & OAEP encoding, so the input size can be at most ~200bytes
+func PkEncryptMessage(publicKey []byte, message []byte) ([]byte, error) {
+	//TODO-1: bump up the key length to 3072 to match NIST strength
+
+	messagePtr := C.CBytes(message)
+	defer C.free(messagePtr)
+
+	publicKeyPtr := C.CBytes(publicKey)
+	defer C.free(publicKeyPtr)
+
+	//the max length of the message to be encrypted is dictated by the pdo crypto lib (see above)
+	if len(message) > int(C.RSA_PLAINTEXT_LEN) {
+		return nil, fmt.Errorf("message message too long for encryption")
+	}
+	//TODO add tests with different message lengths
+	encryptedMessageSize := C.RSA_KEY_SIZE >> 3 //bits-to-bytes conversion
+	encryptedMessagePtr := C.malloc(C.ulong(encryptedMessageSize))
+	defer C.free(encryptedMessagePtr)
+
+	encryptedMessageActualSize := C.uint32_t(0)
+
+	ret := C.pk_encrypt_message(
+		(*C.uint8_t)(publicKeyPtr),
+		C.uint32_t(len(publicKey)),
+		(*C.uint8_t)(messagePtr),
+		C.uint32_t(len(message)),
+		(*C.uint8_t)(encryptedMessagePtr),
+		C.uint32_t(encryptedMessageSize),
+		&encryptedMessageActualSize)
+	if ret == false {
+		return nil, fmt.Errorf("encryption failed")
+	}
+
+	return C.GoBytes(encryptedMessagePtr, C.int(encryptedMessageActualSize)), nil
+}
+
+// DecryptMessage is  symmetric-key encryption performed with the pdo crypto library
+func DecryptMessage(key []byte, encryptedMessage []byte) ([]byte, error) {
+
+	encryptedMessagePtr := C.CBytes(encryptedMessage)
+	defer C.free(encryptedMessagePtr)
+
+	keyPtr := C.CBytes(key)
+	defer C.free(keyPtr)
+
+	// the (decrypted) message size is estimated to be <= the encrypted message size
+	messageSize := len(encryptedMessage)
+	messagePtr := C.malloc(C.ulong(messageSize))
+	defer C.free(messagePtr)
+
+	messageActualSize := C.uint32_t(0)
+
+	ret := C.decrypt_message(
+		(*C.uint8_t)(keyPtr),
+		C.uint32_t(len(key)),
+		(*C.uint8_t)(encryptedMessagePtr),
+		C.uint32_t(len(encryptedMessage)),
+		(*C.uint8_t)(messagePtr),
+		C.uint32_t(messageSize),
+		&messageActualSize)
+	if ret == false {
+		return nil, fmt.Errorf("decryption failed")
+	}
+
+	return C.GoBytes(messagePtr, C.int(messageActualSize)), nil
+}
+
+//EncryptMessage is a symmetric-key encryption performed with the PDO crypto lib
 func EncryptMessage(key []byte, message []byte) (encryptedMessage []byte, e error) {
-	//This is a symmetric-key encryption performed with the PDO crypto lib
 
 	keyPtr := C.CBytes(key)
 	defer C.free(keyPtr)

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -1,0 +1,143 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRSAKeys(t *testing.T) {
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, pubKey)
+	block, _ := pem.Decode(pubKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "RSA PUBLIC KEY", block.Type)
+	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	assert.NotNil(t, pub)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, privKey)
+	block, _ = pem.Decode(privKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "RSA PRIVATE KEY", block.Type)
+	pri, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	assert.NotNil(t, pri)
+	assert.NoError(t, err)
+}
+
+func TestNewECDSAKeys(t *testing.T) {
+	pubKey, privKey, err := NewECDSAKeys()
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, pubKey)
+	block, _ := pem.Decode(pubKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "PUBLIC KEY", block.Type)
+	// TODO check unsupported curve
+	//pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	//assert.NotNil(t, pub)
+	//assert.NoError(t, err)
+
+	assert.NotEmpty(t, privKey)
+	block, _ = pem.Decode(privKey)
+	assert.NotNil(t, block)
+	assert.Equal(t, "EC PRIVATE KEY", block.Type)
+	//pri, err := x509.ParseECPrivateKey(block.Bytes)
+	//assert.NotNil(t, pri)
+	//assert.NoError(t, err)
+}
+
+func TestNewSymmetricKey(t *testing.T) {
+	symKey, err := NewSymmetricKey()
+	assert.NotNil(t, symKey)
+	assert.NoError(t, err)
+}
+
+func TestSignature(t *testing.T) {
+	msg := []byte("some message")
+
+	pubKey, privKey, err := NewECDSAKeys()
+	assert.NotEmpty(t, pubKey)
+	assert.NotEmpty(t, privKey)
+	assert.NoError(t, err)
+
+	// fail with invalid key
+	sig, err := SignMessage([]byte("invalid key"), msg)
+	assert.Nil(t, sig)
+	assert.Error(t, err)
+
+	// should succeed
+	sig, err = SignMessage(privKey, msg)
+	assert.NotNil(t, sig)
+	assert.NoError(t, err)
+
+	err = VerifyMessage([]byte("invalid key"), msg, sig)
+	assert.Error(t, err)
+
+	err = VerifyMessage(pubKey, []byte("invalid msg"), sig)
+	assert.Error(t, err)
+
+	err = VerifyMessage(pubKey, msg, []byte("invalid sig"))
+	assert.Error(t, err)
+
+	// should succeed
+	err = VerifyMessage(pubKey, msg, sig)
+	assert.NoError(t, err)
+}
+
+func TestPkEncryption(t *testing.T) {
+	msg := []byte("some message")
+
+	pubKey, privKey, err := NewRSAKeys()
+	assert.NotEmpty(t, pubKey)
+	assert.NotEmpty(t, privKey)
+	assert.NoError(t, err)
+
+	cipher, err := PkEncryptMessage([]byte("invalid key"), msg)
+	assert.Nil(t, cipher)
+	assert.Error(t, err)
+
+	// should succeed
+	cipher, err = PkEncryptMessage(pubKey, msg)
+	assert.NotNil(t, cipher)
+	assert.NoError(t, err)
+
+	plain, err := PkDecryptMessage([]byte("invalid key"), cipher)
+	assert.Nil(t, plain)
+	assert.Error(t, err)
+
+	// should succeed
+	plain, err = PkDecryptMessage(privKey, cipher)
+	assert.Equal(t, plain, msg)
+	assert.NoError(t, err)
+}
+
+func TestSymEncryption(t *testing.T) {
+	msg := []byte("some message")
+
+	key, err := NewSymmetricKey()
+	assert.NotEmpty(t, key)
+	assert.NoError(t, err)
+
+	cipher, err := EncryptMessage([]byte("invalid key"), msg)
+	assert.Nil(t, cipher)
+	assert.Error(t, err)
+
+	// should succeed
+	cipher, err = EncryptMessage(key, msg)
+	assert.NotNil(t, cipher)
+	assert.NoError(t, err)
+
+	plain, err := DecryptMessage([]byte("invalid key"), cipher)
+	assert.Nil(t, plain)
+	assert.Error(t, err)
+
+	// should succeed
+	plain, err = DecryptMessage(key, cipher)
+	assert.Equal(t, plain, msg)
+	assert.NoError(t, err)
+}

--- a/protos/fpc.options
+++ b/protos/fpc.options
@@ -3,6 +3,7 @@
 fpc.CleartextChaincodeRequest.return_encryption_key type:FT_POINTER
 
 fpc.ChaincodeRequestMessage.encrypted_request type:FT_POINTER
+fpc.ChaincodeRequestMessage.encrypted_request_encryption_key type:FT_POINTER
 
 fpc.FPCKVSet.read_value_hashes type:FT_POINTER
 

--- a/protos/fpc/fpc.proto
+++ b/protos/fpc/fpc.proto
@@ -99,8 +99,11 @@ message CleartextChaincodeRequest {
 }
 
 message ChaincodeRequestMessage {
-    // an RSA-encryption of the serialization of CleartextChaincodeRequest with the chaincode encryption key
+    // an encryption (using the request encryption key (aes128-gcm)) of the serialization of CleartextChaincodeRequest with the chaincode encryption key
     bytes encrypted_request = 1;
+
+    // an RSA-encryption of the request encryption key (aes128-gcm) with the chaincode encryption key
+    bytes encrypted_request_encryption_key = 2;
 }
 
 message CleartextChaincodeResponse {


### PR DESCRIPTION
This introduces a hybrid encryption scheme for fpc requests. Before FPC
requests were encrypted using the chaincode encryption key using
RSA-based encryption. This had the limitation that the maximum payload
size was restricted to ~200bytes. They new scheme uses symmetric
encryption to encrypt the actual request and uses the chaincode
encryption key to encrypt the key used to encrypt the FPC request. The
encrypted request key is added to the request protos. Unit test for go
cryto package and support for mock_ecc were added.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
