### PR TITLE
Support any chaincode name in installFPC.sh

### DIFF
--- a/samples/deployment/test-network/installFPC.sh
+++ b/samples/deployment/test-network/installFPC.sh
@@ -23,7 +23,7 @@ PEERS=("peer0.org1.example.com" "peer0.org2.example.com")
 ERCC_EP="OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer')"
 ECC_EP="OutOf(2, 'Org1MSP.peer', 'Org2MSP.peer')"
 
-CC_ID="echo"
+CC_ID=${CC_ID:="echo"}
 CC_VER="$(cat ${FPC_PATH}/samples/chaincode/${CC_ID}/_build/lib/mrenclave)"
 
 ERCC_ID="ercc"


### PR DESCRIPTION
Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>

**What this PR does / why we need it**:
When executing installFPC.sh, read the CC_ID from the environment variable to install a different chaincode than the echo.
If CC_ID is undefined, "echo" will be defined.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
No

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
No

```
