### PR TITLE
Fixed the version of fabric-ccenv to 2.3.0

### DIFF
--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -20,7 +20,7 @@ fetch: $(FABS_FETCHED)
 
 $(FABS_FETCHED):
 	mkdir -p $(FABS) && cd $(FABS) \
-	&& curl -sSL https://bit.ly/2ysbOFE | bash -s -- $(FABRIC_VERSION) 1.4.9 -s -d \
+	&& curl -sSL https://bit.ly/2ysbOFE | bash -s -- $(FABRIC_VERSION) 1.4.9 -s \
 	&& touch .fetched
 
 


### PR DESCRIPTION
Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>

**What this PR does / why we need it**:

I found a bug in the current main branch and v1.0-rc2 that causes FPC to fail to build (Issue #628).
As a result of discussions with the community, it was found that it was caused by differences in the version of fabric-ccenv.
This PR solves the issue of Issue #628 by setting the version of fabric-ccenv to v2.3.0.

**Which issue(s) this PR fixes**:

Fixes #628

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:

