### PR TITLE
Upgrade go and fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Make sure that you have the following required dependencies installed:
 
 * CMake v3.5.1 or higher
 
-* [Go](https://golang.org/) 1.15.4 or higher
+* [Go](https://golang.org/) 1.16.7 or higher
 
 * Docker 18.09 (or higher) and docker-compose 1.25.x (or higher)
   Note that version from Ubuntu 18.04 is not recent enough!  To upgrade, install a recent version following the instructions from [docker.com](https://docs.docker.com/compose/install/), e.g., for version 1.25.4 execute	

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Make sure that you have the following required dependencies installed:
 * [Intel Software Guard Extensions SSL](https://github.com/intel/intel-sgx-ssl)
   (we recommend using branch `lin_2.10_1.1.1g` OpenSSL `1.1.1g`)
 
-* Hyperledger [Fabric](https://github.com/hyperledger/fabric/tree/v2.3.0) v2.3.0
+* Hyperledger [Fabric](https://github.com/hyperledger/fabric/tree/v2.3.3) v2.3.3
 
 * Clang-format 6.x or higher
 
@@ -344,15 +344,15 @@ export PROTOC_CMD=/usr/local/proto3/bin/protoc
 #### Hyperledger Fabric
 
 Our project fetches the latest supported Fabric binaries during the build process automatically.
-However, if you want to use your own Fabric binaries, please checkout Fabric 2.3.0 release using the following commands:
+However, if you want to use your own Fabric binaries, please checkout Fabric 2.3.3 release using the following commands:
 ```bash
 export FABRIC_PATH=$GOPATH/src/github.com/hyperledger/fabric
 git clone https://github.com/hyperledger/fabric.git $FABRIC_PATH
-cd $FABRIC_PATH; git checkout tags/v2.3.0
+cd $FABRIC_PATH; git checkout tags/v2.3.3
 ```
 
 Note that Fabric Private Chaincode may not work with the Fabric `main` branch.
-Therefore, make sure you use the Fabric `v2.3.0` tag.
+Therefore, make sure you use the Fabric `v2.3.3` tag.
 Make sure the source of Fabric is in your `$GOPATH`.
 
 ## Build Fabric Private Chaincode

--- a/config.mk
+++ b/config.mk
@@ -66,7 +66,7 @@ PLANTUML_IMG_FORMAT ?= png # pdf / png / svg
 #--------------------------------------------------
 PROJECT_NAME=fabric-private-chaincode
 
-export FABRIC_VERSION ?= 2.3.0
+export FABRIC_VERSION ?= 2.3.3
 
 export FPC_VERSION := main
 

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -27,9 +27,9 @@ To clean the native build, type `cd $FPC_PATH/fabric; make clean-native`.
 ### Wrong Fabric version
 ```
 Patching Fabric ...
-Aborting! Tag on current HEAD () does not match expected tag/v2.3.0!
+Aborting! Tag on current HEAD () does not match expected tag/v2.3.3!
 ...
 ```
 
 Seems that your Fabric is on the wrong branch.
-Try to run `pushd $FABRIC_PATH; git checkout tags/v2.3.0; popd;` followed by `make` again.
+Try to run `pushd $FABRIC_PATH; git checkout tags/v2.3.3; popd;` followed by `make` again.

--- a/fabric/bin/peer.sh
+++ b/fabric/bin/peer.sh
@@ -99,7 +99,7 @@ handle_lifecycle_chaincode_package() {
 	    # Above is the flags we really care, but we need also the outputfile
 	    # which doesn't have a flag. So let's enumerate the known no-arg
 	    # flags (i.e., --tls -h/--help), assume all other flags have exactly
-	    # one arg (true as of v2.3.0) and then the remaining one is the
+	    # one arg (true as of v2.3.3) and then the remaining one is the
 	    # output file ...
 	    -h|--help)
 		# with help, no point to continue but run it right here ..
@@ -206,7 +206,7 @@ handle_lifecycle_chaincode_install() {
 	    # we care only about package file name but this is not prefixed
 	    # with a flag.  So let's enumerate the known no-arg flags (i.e.,
 	    # --tls -h/--help), assume all other flags have exactly
-	    # one arg (true as of v2.3.0) and then the remaining one is the
+	    # one arg (true as of v2.3.3) and then the remaining one is the
 	    # output file ...
 	    -h|--help)
 		# with help, no point to continue but run it right here ..

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-private-chaincode
 
-go 1.15
+go 1.16
 
 // Note:
 // - fabric has a go.mod but the normal tagging, e.g., v2.2.0 does NOT

--- a/samples/deployment/k8s/README.md
+++ b/samples/deployment/k8s/README.md
@@ -124,7 +124,7 @@ If you have installed them somewhere else on your system, please set `FABIC_BIN_
 For instance, you can download the binaries and use them by following the commands:
 ```bash
 cd $FPC_PATH/samples/deployment/k8s
-curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.0 1.4.9 -d -s
+curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.3 1.4.9 -d -s
 export FABRIC_BIN_DIR=$(pwd)/bin
 ```
 

--- a/samples/deployment/k8s/orderer-service/orderer0-deployment.yaml
+++ b/samples/deployment/k8s/orderer-service/orderer0-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:2.3.0
+          image: hyperledger/fabric-orderer:2.3.3
           name: orderer
           ports:
             - containerPort: 7050

--- a/samples/deployment/k8s/orderer-service/orderer1-deployment.yaml
+++ b/samples/deployment/k8s/orderer-service/orderer1-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:2.3.0
+          image: hyperledger/fabric-orderer:2.3.3
           name: orderer
           ports:
             - containerPort: 7050

--- a/samples/deployment/k8s/orderer-service/orderer2-deployment.yaml
+++ b/samples/deployment/k8s/orderer-service/orderer2-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:2.3.0
+          image: hyperledger/fabric-orderer:2.3.3
           name: orderer
           ports:
             - containerPort: 7050

--- a/samples/deployment/k8s/org1/org1-cli-deployment.yaml
+++ b/samples/deployment/k8s/org1/org1-cli-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 configMapKeyRef:
                   name: chaincode-config
                   key: FPC_MRENCLAVE
-          image: hyperledger/fabric-tools:2.3.0
+          image: hyperledger/fabric-tools:2.3.3
           name: cli
           tty: true
           volumeMounts:

--- a/samples/deployment/k8s/org1/org1-peer0-deployment.yaml
+++ b/samples/deployment/k8s/org1/org1-peer0-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: 0.0.0.0:9443
             - name: CORE_METRICS_PROVIDER
               value: prometheus
-          image: hyperledger/fabric-peer:2.3.0
+          image: hyperledger/fabric-peer:2.3.3
           name: peer0
           ports:
             - containerPort: 7051

--- a/samples/deployment/k8s/org2/org2-cli-deployment.yaml
+++ b/samples/deployment/k8s/org2/org2-cli-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 configMapKeyRef:
                   name: chaincode-config
                   key: FPC_MRENCLAVE
-          image: hyperledger/fabric-tools:2.3.0
+          image: hyperledger/fabric-tools:2.3.3
           name: cli
           tty: true
           volumeMounts:

--- a/samples/deployment/k8s/org2/org2-peer0-deployment.yaml
+++ b/samples/deployment/k8s/org2/org2-peer0-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: 0.0.0.0:9443
             - name: CORE_METRICS_PROVIDER
               value: prometheus
-          image: hyperledger/fabric-peer:2.3.0
+          image: hyperledger/fabric-peer:2.3.3
           name: peer0
           ports:
             - containerPort: 7051

--- a/samples/deployment/k8s/org3/org3-cli-deployment.yaml
+++ b/samples/deployment/k8s/org3/org3-cli-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 configMapKeyRef:
                   name: chaincode-config
                   key: FPC_MRENCLAVE
-          image: hyperledger/fabric-tools:2.3.0
+          image: hyperledger/fabric-tools:2.3.3
           name: cli
           tty: true
           volumeMounts:

--- a/samples/deployment/k8s/org3/org3-peer0-deployment.yaml
+++ b/samples/deployment/k8s/org3/org3-peer0-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               value: 0.0.0.0:9443
             - name: CORE_METRICS_PROVIDER
               value: prometheus
-          image: hyperledger/fabric-peer:2.3.0
+          image: hyperledger/fabric-peer:2.3.3
           name: peer0
           ports:
             - containerPort: 7051

--- a/samples/deployment/test-network/README.md
+++ b/samples/deployment/test-network/README.md
@@ -36,9 +36,9 @@ Next, setup fabric sample network, binaries and docker images. Here we follow th
 
 ```bash
 cd $FPC_PATH/samples/deployment/test-network
-git clone https://github.com/hyperledger/fabric-samples -b v2.3.0
+git clone https://github.com/hyperledger/fabric-samples -b v2.3.3
 cd $FPC_PATH/samples/deployment/test-network/fabric-samples
-curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.0 1.4.9 -s
+curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.3 1.4.9 -s
 ```
 
 Before we can start the network, we need to update the Fabric peer configuration to enable FPC support.
@@ -71,7 +71,7 @@ Let's start the Fabric-Samples test network.
 ```bash
 cd $FPC_PATH/samples/deployment/test-network/fabric-samples/test-network
 ./network.sh up
-./network.sh createChannel -c mychannel -ca -cai 1.4.9 -i 2.3.0
+./network.sh createChannel -c mychannel -ca -cai 1.4.9 -i 2.3.3
 ```
 
 Next, we install the FPC Enclave Registry and our FPC Chaincode on the network by using the standard Lifecycle commands,

--- a/samples/deployment/test-network/README.md
+++ b/samples/deployment/test-network/README.md
@@ -36,7 +36,7 @@ Next, setup fabric sample network, binaries and docker images. Here we follow th
 
 ```bash
 cd $FPC_PATH/samples/deployment/test-network
-git clone https://github.com/hyperledger/fabric-samples -b v2.3.3
+git clone https://github.com/hyperledger/fabric-samples
 cd $FPC_PATH/samples/deployment/test-network/fabric-samples
 curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.3.3 1.4.9 -s
 ```
@@ -70,8 +70,8 @@ cd $FPC_PATH/samples/deployment/test-network
 Let's start the Fabric-Samples test network.
 ```bash
 cd $FPC_PATH/samples/deployment/test-network/fabric-samples/test-network
-./network.sh up
-./network.sh createChannel -c mychannel -ca -cai 1.4.9 -i 2.3.3
+./network.sh up -ca
+./network.sh createChannel -c mychannel
 ```
 
 Next, we install the FPC Enclave Registry and our FPC Chaincode on the network by using the standard Lifecycle commands,

--- a/samples/deployment/test-network/docker-compose.yml
+++ b/samples/deployment/test-network/docker-compose.yml
@@ -71,4 +71,4 @@ services:
 networks:
   default:
     external:
-      name: net_test
+      name: fabric_test

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -20,7 +20,7 @@ ARG FPC_VERSION=main
 FROM hyperledger/fabric-private-chaincode-base-rt:${FPC_VERSION} as common
 
 # config/build params
-ARG GO_VERSION=1.15.4
+ARG GO_VERSION=1.16.7
 ARG NANOPB_VERSION=0.4.3
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g

--- a/utils/docker/dev/Dockerfile
+++ b/utils/docker/dev/Dockerfile
@@ -23,7 +23,7 @@ FROM hyperledger/fabric-private-chaincode-base-dev:${FPC_VERSION}
 
 # config/build params
 ARG FABRIC_REPO=https://github.com/hyperledger/fabric.git
-ARG FABRIC_VERSION=2.3.0
+ARG FABRIC_VERSION=2.3.3
 
 ARG FABRIC_REL_PATH=src/github.com/hyperledger/fabric
 ARG FPC_REL_PATH=src/github.com/hyperledger/fabric-private-chaincode

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -53,7 +53,7 @@ ARG SGX_MODE
 
 # config/build params
 ARG FABRIC_REPO=https://github.com/hyperledger/fabric.git
-ARG FABRIC_VERSION=2.3.0
+ARG FABRIC_VERSION=2.3.3
 ARG FPC_REPO_URL=https://github.com/hyperledger/fabric-private-chaincode.git
 ARG FPC_REPO_BRANCH_TAG_OR_COMMIT=main
 ARG GIT_USER_NAME=tester


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR upgrade go version to 1.16.7, the same version as currently used by Fabric. Also, we upgrade to the most recent version of Fabric 2.3.3. The main reason for upgrading to this fabric version is to resolve compatibility issues between 2.3.0 and 2.3.3 as already mentioned in #629. 

**Special notes for your reviewer**:
Note that in the test-network tutorial, we are now using the main branch for fabric-samples as there is no 2.3.3 tag yet available. The previous tag 2.3.0, we used, is not compatible with Fabric 2.3.3. 

