### PR TITLE
Add del_state support

### DIFF
--- a/ecc/chaincode/enclave/shim.go
+++ b/ecc/chaincode/enclave/shim.go
@@ -182,3 +182,20 @@ func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max
 	C._cpy_bytes(values, (*C.uint8_t)(C.CBytes(data)), C.uint32_t(len(data)))
 	C._set_int(values_len, C.uint32_t(len(data)))
 }
+
+//export del_state
+func del_state(key *C.char, ctx unsafe.Pointer) {
+	stubs := registry.get(*(*int)(ctx))
+
+	// check if composite key
+	key_str := C.GoString(key)
+	if utils.IsFPCCompositeKey(key_str) {
+		comp := utils.SplitFPCCompositeKey(key_str)
+		key_str, _ = stubs.shimStub.CreateCompositeKey(comp[0], comp[1:])
+	}
+
+	err := stubs.shimStub.DelState(key_str)
+	if err != nil {
+		panic("error while deleting state")
+	}
+}

--- a/ecc_enclave/enclave/enclave.edl
+++ b/ecc_enclave/enclave/enclave.edl
@@ -35,6 +35,10 @@ enclave {
                 [in, string] const char *comp_key,
                 [out, size=max_len] uint8_t *values, uint32_t max_len, [out] uint32_t *values_len,
                 [user_check] void *u_shim_ctx);
+
+        void ocall_del_state(
+                [in, string] const char *key,
+                [user_check] void *u_shim_ctx);
     };
 
 };

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -170,6 +170,7 @@ void put_public_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_
     // save write -- only the last one for the same key
     ctx->write_set.erase(key);
     ctx->write_set.insert({key, ByteArray(val, val + val_len)});
+    ctx->del_set.erase(key);
 
     ocall_put_state(key, val, val_len, ctx->u_shim_ctx);
 }
@@ -248,6 +249,15 @@ void get_public_state_by_partial_composite_key(
     }
 
     unmarshal_values(values, (const char*)json, len);
+}
+
+void del_state(const char* key, shim_ctx_ptr_t ctx)
+{
+    ctx->write_set.erase(key);
+    ctx->del_set.insert(key);
+
+    ocall_del_state(key, ctx->u_shim_ctx);
+    return;
 }
 
 int get_string_args(std::vector<std::string>& argss, shim_ctx_ptr_t ctx)

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -166,6 +166,9 @@ void get_public_state_by_partial_composite_key(
 //
 // - other functions: {get,set}StateValidationParameter, getHistoryForKey. Can/should we ignore?
 
+// - records the given `key` to be deleted in the writeset.
+void del_state(const char* key, shim_ctx_ptr_t ctx);
+
 // retrieval for arguments
 //-------------------------------------------------
 // - retrieve the list of invocation parameters

--- a/ecc_enclave/enclave/shim_internals.cpp
+++ b/ecc_enclave/enclave/shim_internals.cpp
@@ -101,7 +101,8 @@ bool rwset_to_proto(t_shim_ctx_t* ctx, fpc_FPCKVSet* fpc_rwset_proto)
     LOG_DEBUG("Add del_set items");
     for (auto it = ctx->del_set.begin(); it != ctx->del_set.end(); it++, i++)
     {
-        // note that we continue to use i without resetting since we are appending to the rw_set.writes
+        // note that we continue to use i without resetting since we are appending to the
+        // rw_set.writes
         LOG_DEBUG("k=%s", it->c_str());
 
         // serialize write
@@ -110,11 +111,13 @@ bool rwset_to_proto(t_shim_ctx_t* ctx, fpc_FPCKVSet* fpc_rwset_proto)
         // serialize key
         fpc_rwset_proto->rw_set.writes[i].key = (char*)pb_realloc(NULL, it->length() + 1);
         COND2ERR(fpc_rwset_proto->rw_set.writes[i].key == NULL);
-        ret = memcpy_s(fpc_rwset_proto->rw_set.writes[i].key, it->length(), it->c_str(), it->length());
+        ret = memcpy_s(
+            fpc_rwset_proto->rw_set.writes[i].key, it->length(), it->c_str(), it->length());
         fpc_rwset_proto->rw_set.writes[i].key[it->length()] = '\0';
         COND2ERR(ret != 0);
 
-        fpc_rwset_proto->rw_set.writes[i].value = (pb_bytes_array_t*)pb_realloc(NULL, PB_BYTES_ARRAY_T_ALLOCSIZE(0));
+        fpc_rwset_proto->rw_set.writes[i].value =
+            (pb_bytes_array_t*)pb_realloc(NULL, PB_BYTES_ARRAY_T_ALLOCSIZE(0));
         COND2ERR(fpc_rwset_proto->rw_set.writes[i].value == NULL);
     }
 

--- a/ecc_enclave/enclave/shim_internals.h
+++ b/ecc_enclave/enclave/shim_internals.h
@@ -11,7 +11,6 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <set>
 #include "types.h"
 
 // read/writeset

--- a/ecc_enclave/enclave/shim_internals.h
+++ b/ecc_enclave/enclave/shim_internals.h
@@ -11,11 +11,13 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <set>
 #include "types.h"
 
 // read/writeset
 typedef std::map<std::string, ByteArray> write_set_t;
 typedef std::map<std::string, ByteArray> read_set_t;
+typedef std::set<std::string> del_set_t;
 
 // shim context
 typedef struct t_shim_ctx
@@ -23,6 +25,7 @@ typedef struct t_shim_ctx
     void* u_shim_ctx;
     read_set_t read_set;
     write_set_t write_set;
+    del_set_t del_set;
     std::vector<std::string> string_args;
     ByteArray signed_proposal;
     std::string tx_id;

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -18,6 +18,7 @@ extern void get_state(
 extern void get_state_by_partial_composite_key(
     const char* comp_key, uint8_t* values, uint32_t max_len, uint32_t* values_len, void* ctx);
 extern void put_state(const char* key, uint8_t* val, uint32_t val_len, void* ctx);
+extern void del_state(const char* key, void* ctx);
 
 int sgxcc_invoke(enclave_id_t eid,
     const uint8_t* signed_proposal_proto_bytes,
@@ -55,4 +56,10 @@ void ocall_get_state_by_partial_composite_key(
     const char* key, uint8_t* bids_bytes, uint32_t max_len, uint32_t* bids_bytes_len, void* ctx)
 {
     get_state_by_partial_composite_key(key, bids_bytes, max_len, bids_bytes_len, ctx);
+}
+
+void ocall_del_state(
+    const char* key, void* ctx)
+{
+    del_state(key, ctx);
 }

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -58,8 +58,7 @@ void ocall_get_state_by_partial_composite_key(
     get_state_by_partial_composite_key(key, bids_bytes, max_len, bids_bytes_len, ctx);
 }
 
-void ocall_del_state(
-    const char* key, void* ctx)
+void ocall_del_state(const char* key, void* ctx)
 {
     del_state(key, ctx);
 }

--- a/integration/client_sdk/go/stress_test/stress_test.go
+++ b/integration/client_sdk/go/stress_test/stress_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Stress tests", func() {
 
 					_, err = echoContract.EvaluateTransaction("del_state", key)
 					Expect(err).ShouldNot(HaveOccurred())
+					Expect(res).Should(Equal([]byte("OK")))
 				}
 			})
 		})

--- a/integration/client_sdk/go/stress_test/stress_test.go
+++ b/integration/client_sdk/go/stress_test/stress_test.go
@@ -35,8 +35,8 @@ const (
 )
 
 var (
-	network      *gateway.Network
-	echoContract fpc.Contract
+	network  *gateway.Network
+	contract fpc.Contract
 )
 
 var _ = BeforeSuite(func() {
@@ -53,8 +53,8 @@ var _ = BeforeSuite(func() {
 	Expect(network).ShouldNot(BeNil())
 
 	// Get FPC Contract
-	echoContract = fpc.GetContract(network, ccID)
-	Expect(echoContract).ShouldNot(BeNil())
+	contract = fpc.GetContract(network, ccID)
+	Expect(contract).ShouldNot(BeNil())
 })
 
 var _ = Describe("Stress tests", func() {
@@ -73,15 +73,15 @@ var _ = Describe("Stress tests", func() {
 					key := "some-key"
 					value := base64.StdEncoding.EncodeToString(payload)
 
-					res, err := echoContract.SubmitTransaction("put_state", key, value)
+					res, err := contract.SubmitTransaction("put_state", key, value)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).Should(Equal([]byte("OK")))
 
-					res, err = echoContract.EvaluateTransaction("get_state", key)
+					res, err = contract.EvaluateTransaction("get_state", key)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).Should(Equal([]byte(value)))
 
-					_, err = echoContract.EvaluateTransaction("del_state", key)
+					res, err = contract.SubmitTransaction("del_state", key)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).Should(Equal([]byte("OK")))
 				}
@@ -103,7 +103,7 @@ var _ = Describe("Stress tests", func() {
 				Expect(n).Should(Equal(size))
 
 				value := base64.StdEncoding.EncodeToString(payload)
-				res, err := echoContract.SubmitTransaction("put_state", key, value)
+				res, err := contract.SubmitTransaction("put_state", key, value)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(res).Should(Equal([]byte("OK")))
 
@@ -112,7 +112,7 @@ var _ = Describe("Stress tests", func() {
 					if i%10 == 0 {
 						fmt.Printf("i=%d\n", i)
 					}
-					res, err = echoContract.EvaluateTransaction("get_state", key)
+					res, err = contract.EvaluateTransaction("get_state", key)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).Should(Equal([]byte(value)))
 				}

--- a/integration/client_sdk/go/stress_test/stress_test.go
+++ b/integration/client_sdk/go/stress_test/stress_test.go
@@ -73,6 +73,9 @@ var _ = Describe("Stress tests", func() {
 					res, err = echoContract.EvaluateTransaction("get_state", key)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).Should(Equal([]byte(value)))
+
+					_, err = echoContract.EvaluateTransaction("del_state", key)
+					Expect(err).ShouldNot(HaveOccurred())
 				}
 			})
 		})

--- a/integration/kv_test.sh
+++ b/integration/kv_test.sh
@@ -42,6 +42,8 @@ kv_test() {
     try ${PEER_CMD} lifecycle chaincode querycommitted -C ${CHAN_ID}
 
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"put_state", "Args": ["echo-0", "echo-0"]}' --waitForEvent
+    try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"get_state", "Args": ["echo-0"]}' --waitForEvent
+    try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"del_state", "Args": ["echo-0"]}' --waitForEvent
     check_result "OK"
 }
 

--- a/integration/kv_test.sh
+++ b/integration/kv_test.sh
@@ -44,7 +44,7 @@ kv_test() {
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"put_state", "Args": ["echo-0", "echo-0"]}' --waitForEvent
     check_result "OK"
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"get_state", "Args": ["echo-0"]}' --waitForEvent
-    check_result "OK"
+    check_result "echo-0"
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"del_state", "Args": ["echo-0"]}' --waitForEvent
     check_result "OK"
 }

--- a/integration/kv_test.sh
+++ b/integration/kv_test.sh
@@ -42,7 +42,9 @@ kv_test() {
     try ${PEER_CMD} lifecycle chaincode querycommitted -C ${CHAN_ID}
 
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"put_state", "Args": ["echo-0", "echo-0"]}' --waitForEvent
+    check_result "OK"
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"get_state", "Args": ["echo-0"]}' --waitForEvent
+    check_result "OK"
     try_out_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"del_state", "Args": ["echo-0"]}' --waitForEvent
     check_result "OK"
 }

--- a/samples/chaincode/kv-test/kv-test-cc.cpp
+++ b/samples/chaincode/kv-test/kv-test-cc.cpp
@@ -59,6 +59,18 @@ int invoke(
                 result = std::string((const char*)value, actual_value_len);
         }
     }
+    else if (function_name == "del_state")
+    {
+        if (params.size() != 1)
+        {
+            result = std::string("del_state needs 1 parameter: key");
+        }
+        else
+        {
+            del_state(params[0].c_str(), ctx);
+            result = std::string("OK");
+        }
+    }
     else
     {
         result = std::string("BAD FUNCTION");

--- a/samples/chaincode/kv-test/kv-test-cc.cpp
+++ b/samples/chaincode/kv-test/kv-test-cc.cpp
@@ -22,6 +22,8 @@ int invoke(
     std::string result;
     get_func_and_params(function_name, params, ctx);
 
+    LOG_DEBUG("Call function: %s", function_name.c_str());
+
     if (function_name == "put_state")
     {
         if (params.size() != 2)


### PR DESCRIPTION
This PR adds `del_state` to the FPC shim.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>
