### PR TITLE
corrected link in test-network readme

### DIFF
--- a/samples/deployment/test-network/README.md
+++ b/samples/deployment/test-network/README.md
@@ -195,7 +195,7 @@ In this section we show how you can run a different FPC chaincode on the test ne
 export CC_ID=helloworld
 export CC_PATH=$FPC_PATH/samples/chaincode/helloworld
 ```
-Afterwards to test you would use [simple-cli-go](###How-to-use-simple-cli-go). You would need to verify that the `CC_NAME` variable is set to helloworld and then to interact you would execute the chaincode as follows:
+Afterwards to test you would use [simple-cli-go](#How-to-use-simple-cli-go). You would need to verify that the `CC_NAME` variable is set to helloworld and then to interact you would execute the chaincode as follows:
 ```bash
 # interact with the FPC Chaincode
 ./fpcclient invoke storeAsset asset1 100


### PR DESCRIPTION
Signed-off-by: munapower <mmunaro@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:
Corrects link in readme of test-network sample
**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
User clicks on simple-cli-go hyperlink in "Using HelloWorld chaincode on the test-network" section and is taken nowhere.
```
