### PR TITLE
Fix configuration path for case-sensitive fs

### DIFF
--- a/samples/application/simple-go/main.go
+++ b/samples/application/simple-go/main.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/hyperledger/fabric-private-chaincode/client_sdk/go/pkg/client/resmgmt"
 	fpc "github.com/hyperledger/fabric-private-chaincode/client_sdk/go/pkg/gateway"
@@ -100,8 +101,8 @@ func main() {
 
 	ccID := getEnvWithFallback("CC_ID", "echo")
 	channelID := getEnvWithFallback("CHANNEL_ID", "mychannel")
-	orgName := getEnvWithFallback("ORG_NAME", "org1")
-	orgNameFull := getEnvWithFallback("ORG_NAME_FULL", orgName+".example.com")
+	orgName := getEnvWithFallback("ORG_NAME", "Org1")
+	orgNameFull := getEnvWithFallback("ORG_NAME_FULL", strings.ToLower(orgName)+".example.com")
 	mspId := getEnvWithFallback("MSP_ID", orgName+"MSP")
 	userId := getEnvWithFallback("USER_ID", "User1")
 
@@ -125,7 +126,7 @@ func main() {
 		"organizations",
 		"peerOrganizations",
 		orgNameFull,
-		fmt.Sprintf("connection-%s.yaml", orgName),
+		fmt.Sprintf("connection-%s.yaml", strings.ToLower(orgName)),
 	))
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/samples/deployment/test-network/README.md
+++ b/samples/deployment/test-network/README.md
@@ -136,7 +136,11 @@ cd $FPC_PATH/samples/deployment/test-network
 Now we will use the go app in `$FPC_PATH/samples/application/simple-go` to demonstrate the usage of the FPC Client SDK.
 In order to initiate the FPC Chaincode enclave and register it with the FPC Enclave Registry, run the app with the `-withLifecycleInitEnclave` flag.
 
+
 ```bash
+# for SGX HW mode make sure you set the SGX_CREDENTIALS_PATH path; for simulation mode this is not necessary
+export SGX_CREDENTIALS_PATH=$FPC_PATH/config/ias
+
 cd $FPC_PATH/samples/application/simple-go
 CC_ID=echo ORG_NAME=Org1 go run . -withLifecycleInitEnclave
 ```
@@ -171,6 +175,8 @@ export CORE_PEER_TLS_KEY_FILE=$FPC_PATH/samples/deployment/test-network/fabric-s
 export CORE_PEER_TLS_ROOTCERT_FILE=$FPC_PATH/samples/deployment/test-network/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
 export ORDERER_CA=$FPC_PATH/samples/deployment/test-network/fabric-samples/test-network/organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
 export GATEWAY_CONFIG=$FPC_PATH/samples/deployment/test-network/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/connection-org1.yaml
+
+# for SGX HW mode make sure you set the SGX_CREDENTIALS_PATH path; for simulation mode this is not necessary
 export SGX_CREDENTIALS_PATH=$FPC_PATH/config/ias
 
 # init our enclave


### PR DESCRIPTION
The client SDK needs to load the configuration file from the file
system. In this sample app we use the configurations provided in
fabric-samples/test-network. On a case-sensitive fs (Linux), the
constructed path (ccpPath) in this demo app is not correct. We fix
this by demo by using strings.ToLower as we know the path already.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>



**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
The problem is described in #656. This PR fixes the problem with simple-go.


