### PR TITLE
Refactor attestation API for FPC Go Chaincode

### DIFF
--- a/client_sdk/go/pkg/core/lifecycle/client.go
+++ b/client_sdk/go/pkg/core/lifecycle/client.go
@@ -94,7 +94,7 @@ func New(getChannelClient GetChannelClientFunction) (*Client, error) {
 		return nil, errors.Errorf("invalid arguments, channel client loader is nil")
 	}
 
-	converter := attestation.NewCredentialConverter()
+	converter := attestation.NewDefaultCredentialConverter()
 	return &Client{GetChannelClient: getChannelClient, Converter: converter}, nil
 }
 

--- a/common/crypto/attestation-api/test/conversion_app_go/main.go
+++ b/common/crypto/attestation-api/test/conversion_app_go/main.go
@@ -58,7 +58,7 @@ func convert(input []byte) ([]byte, error) {
 	credentialsOnlyAttestation := utils.MarshallProtoBase64(credentials)
 
 	// conversion
-	converter := attestation.NewCredentialConverter()
+	converter := attestation.NewDefaultCredentialConverter()
 	credentialsStringOut, err := converter.ConvertCredentials(credentialsOnlyAttestation)
 	if err != nil {
 		return nil, errors.Wrap(err, "ERROR: couldn't convert credentials")

--- a/common/crypto/attestation-api/test/verify_evidence_app_go/main.go
+++ b/common/crypto/attestation-api/test/verify_evidence_app_go/main.go
@@ -1,0 +1,71 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// this tool is meant to be used in `$FPC_PATH/common/crypto/attestation-api/test` to ensure compatibility
+// with the shell-based attestation verification implementation in `$FPC_PATH/common/crypto/attestation-api/evidence`.
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/epid/pdo"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/simulation"
+	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func main() {
+
+	evidenceJson, err := readFile("verify_evidence_input.txt")
+	exitIfError(err)
+
+	statementJson, err := readFile("statement.txt")
+	exitIfError(err)
+
+	expectedMrenclave, err := readFile("code_id.txt")
+	exitIfError(err)
+
+	verifier := attestation.NewCredentialVerifier(
+		simulation.NewSimulationVerifier(),
+		pdo.NewEpidLinkableVerifier(),
+		pdo.NewEpidUnlinkableVerifier(),
+	)
+
+	cred := &protos.Credentials{
+		SerializedAttestedData: &anypb.Any{
+			Value: []byte(statementJson),
+		},
+		Evidence: []byte(evidenceJson),
+	}
+
+	err = verifier.VerifyCredentials(cred, expectedMrenclave)
+	exitIfError(err)
+}
+
+func exitIfError(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func readFile(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "could not read %s", path)
+	}
+
+	if len(content) == 0 {
+		return "", errors.Errorf("empty file %s", path)
+	}
+
+	return strings.TrimSuffix(string(content), "\n"), nil
+}

--- a/ecc_go/chaincode/enclave_go/attestation/attestation.go
+++ b/ecc_go/chaincode/enclave_go/attestation/attestation.go
@@ -1,0 +1,23 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+import (
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/simulation"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func Issue(attestedData *anypb.Any) ([]byte, error) {
+	issuer := simulation.NewSimulationIssuer()
+	att, err := issuer.Issue(attestedData.Value)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get attestation")
+	}
+
+	return att, nil
+}

--- a/ecc_go/chaincode/enclave_go/enclave.go
+++ b/ecc_go/chaincode/enclave_go/enclave.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric-private-chaincode/ecc_go/chaincode/enclave_go/attestation"
 	"github.com/hyperledger/fabric-private-chaincode/internal/crypto"
 	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
 	"github.com/hyperledger/fabric/bccsp"
@@ -87,13 +88,13 @@ func (e *EnclaveStub) Init(serializedChaincodeParams, serializedHostParamsBytes,
 		ChaincodeEk: e.ccKeys.GetPublicKey(),
 	})
 
-	attestation, err := createAttestation(serializedAttestedData)
+	att, err := attestation.Issue(serializedAttestedData)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create attestation")
 	}
 
 	credentials := &protos.Credentials{
-		Attestation:            attestation,
+		Attestation:            att,
 		SerializedAttestedData: serializedAttestedData,
 	}
 
@@ -345,10 +346,4 @@ func (e *EnclaveStub) extractCleartextChaincodeRequest(chaincodeRequestMessage *
 	}
 
 	return cleartextChaincodeRequest, nil
-}
-
-func createAttestation(attestedData *anypb.Any) ([]byte, error) {
-	// Not implemented for preview
-	// TODO implement proper attestation, supporting dcap and simulation
-	return []byte("{\"attestation_type\":\"simulated\",\"attestation\":\"MA==\"}"), nil
 }

--- a/ercc/main.go
+++ b/ercc/main.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
-	"github.com/hyperledger/fabric-private-chaincode/ercc/attestation"
 	"github.com/hyperledger/fabric-private-chaincode/ercc/registry"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/epid/pdo"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/simulation"
 	"github.com/hyperledger/fabric-private-chaincode/internal/utils"
 	"github.com/hyperledger/fabric/common/flogging"
 )
@@ -26,7 +28,11 @@ func main() {
 	// For example: FABRIC_LOGGING_SPEC=ecc=DEBUG:ecc_enclave=ERROR
 
 	c := &registry.Contract{}
-	c.Verifier = attestation.NewVerifier()
+	c.Verifier = attestation.NewCredentialVerifier(
+		simulation.NewSimulationVerifier(),
+		pdo.NewEpidLinkableVerifier(),
+		pdo.NewEpidUnlinkableVerifier(),
+	)
 	c.IEvaluator = &utils.IdentityEvaluator{}
 	c.BeforeTransaction = registry.MyBeforeTransaction
 

--- a/ercc/registry/fakes/verifier.go
+++ b/ercc/registry/fakes/verifier.go
@@ -3,104 +3,93 @@ package fakes
 
 import (
 	"sync"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
 )
 
-type AttestationVerifier struct {
-	VerifyEvidenceStub        func([]byte, []byte, string) error
-	verifyEvidenceMutex       sync.RWMutex
-	verifyEvidenceArgsForCall []struct {
-		arg1 []byte
-		arg2 []byte
-		arg3 string
+type CredentialVerifier struct {
+	VerifyCredentialsStub        func(*protos.Credentials, string) error
+	verifyCredentialsMutex       sync.RWMutex
+	verifyCredentialsArgsForCall []struct {
+		arg1 *protos.Credentials
+		arg2 string
 	}
-	verifyEvidenceReturns struct {
+	verifyCredentialsReturns struct {
 		result1 error
 	}
-	verifyEvidenceReturnsOnCall map[int]struct {
+	verifyCredentialsReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *AttestationVerifier) VerifyEvidence(arg1 []byte, arg2 []byte, arg3 string) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.verifyEvidenceMutex.Lock()
-	ret, specificReturn := fake.verifyEvidenceReturnsOnCall[len(fake.verifyEvidenceArgsForCall)]
-	fake.verifyEvidenceArgsForCall = append(fake.verifyEvidenceArgsForCall, struct {
-		arg1 []byte
-		arg2 []byte
-		arg3 string
-	}{arg1Copy, arg2Copy, arg3})
-	stub := fake.VerifyEvidenceStub
-	fakeReturns := fake.verifyEvidenceReturns
-	fake.recordInvocation("VerifyEvidence", []interface{}{arg1Copy, arg2Copy, arg3})
-	fake.verifyEvidenceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+func (fake *CredentialVerifier) VerifyCredentials(arg1 *protos.Credentials, arg2 string) error {
+	fake.verifyCredentialsMutex.Lock()
+	ret, specificReturn := fake.verifyCredentialsReturnsOnCall[len(fake.verifyCredentialsArgsForCall)]
+	fake.verifyCredentialsArgsForCall = append(fake.verifyCredentialsArgsForCall, struct {
+		arg1 *protos.Credentials
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("VerifyCredentials", []interface{}{arg1, arg2})
+	fake.verifyCredentialsMutex.Unlock()
+	if fake.VerifyCredentialsStub != nil {
+		return fake.VerifyCredentialsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.verifyCredentialsReturns
 	return fakeReturns.result1
 }
 
-func (fake *AttestationVerifier) VerifyEvidenceCallCount() int {
-	fake.verifyEvidenceMutex.RLock()
-	defer fake.verifyEvidenceMutex.RUnlock()
-	return len(fake.verifyEvidenceArgsForCall)
+func (fake *CredentialVerifier) VerifyCredentialsCallCount() int {
+	fake.verifyCredentialsMutex.RLock()
+	defer fake.verifyCredentialsMutex.RUnlock()
+	return len(fake.verifyCredentialsArgsForCall)
 }
 
-func (fake *AttestationVerifier) VerifyEvidenceCalls(stub func([]byte, []byte, string) error) {
-	fake.verifyEvidenceMutex.Lock()
-	defer fake.verifyEvidenceMutex.Unlock()
-	fake.VerifyEvidenceStub = stub
+func (fake *CredentialVerifier) VerifyCredentialsCalls(stub func(*protos.Credentials, string) error) {
+	fake.verifyCredentialsMutex.Lock()
+	defer fake.verifyCredentialsMutex.Unlock()
+	fake.VerifyCredentialsStub = stub
 }
 
-func (fake *AttestationVerifier) VerifyEvidenceArgsForCall(i int) ([]byte, []byte, string) {
-	fake.verifyEvidenceMutex.RLock()
-	defer fake.verifyEvidenceMutex.RUnlock()
-	argsForCall := fake.verifyEvidenceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+func (fake *CredentialVerifier) VerifyCredentialsArgsForCall(i int) (*protos.Credentials, string) {
+	fake.verifyCredentialsMutex.RLock()
+	defer fake.verifyCredentialsMutex.RUnlock()
+	argsForCall := fake.verifyCredentialsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *AttestationVerifier) VerifyEvidenceReturns(result1 error) {
-	fake.verifyEvidenceMutex.Lock()
-	defer fake.verifyEvidenceMutex.Unlock()
-	fake.VerifyEvidenceStub = nil
-	fake.verifyEvidenceReturns = struct {
+func (fake *CredentialVerifier) VerifyCredentialsReturns(result1 error) {
+	fake.verifyCredentialsMutex.Lock()
+	defer fake.verifyCredentialsMutex.Unlock()
+	fake.VerifyCredentialsStub = nil
+	fake.verifyCredentialsReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *AttestationVerifier) VerifyEvidenceReturnsOnCall(i int, result1 error) {
-	fake.verifyEvidenceMutex.Lock()
-	defer fake.verifyEvidenceMutex.Unlock()
-	fake.VerifyEvidenceStub = nil
-	if fake.verifyEvidenceReturnsOnCall == nil {
-		fake.verifyEvidenceReturnsOnCall = make(map[int]struct {
+func (fake *CredentialVerifier) VerifyCredentialsReturnsOnCall(i int, result1 error) {
+	fake.verifyCredentialsMutex.Lock()
+	defer fake.verifyCredentialsMutex.Unlock()
+	fake.VerifyCredentialsStub = nil
+	if fake.verifyCredentialsReturnsOnCall == nil {
+		fake.verifyCredentialsReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.verifyEvidenceReturnsOnCall[i] = struct {
+	fake.verifyCredentialsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *AttestationVerifier) Invocations() map[string][][]interface{} {
+func (fake *CredentialVerifier) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.verifyEvidenceMutex.RLock()
-	defer fake.verifyEvidenceMutex.RUnlock()
+	fake.verifyCredentialsMutex.RLock()
+	defer fake.verifyCredentialsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
@@ -108,7 +97,7 @@ func (fake *AttestationVerifier) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *AttestationVerifier) recordInvocation(key string, args []interface{}) {
+func (fake *CredentialVerifier) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {

--- a/ercc/registry/registry.go
+++ b/ercc/registry/registry.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
-	"github.com/hyperledger/fabric-private-chaincode/ercc/attestation"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation"
 	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
 	"github.com/hyperledger/fabric-private-chaincode/internal/utils"
 	"github.com/hyperledger/fabric/common/flogging"
@@ -26,7 +26,7 @@ var logger = flogging.MustGetLogger("ercc")
 type Contract struct {
 	contractapi.Contract
 
-	Verifier   attestation.VerifierInterface
+	Verifier   attestation.Verifier
 	IEvaluator utils.IdentityEvaluatorInterface
 }
 
@@ -306,7 +306,7 @@ func (rs *Contract) RegisterEnclave(ctx contractapi.TransactionContextInterface,
 	return nil
 }
 
-func checkAttestedData(ctx contractapi.TransactionContextInterface, v attestation.VerifierInterface, ie utils.IdentityEvaluatorInterface, attestedData *protos.AttestedData, credentials *protos.Credentials) error {
+func checkAttestedData(ctx contractapi.TransactionContextInterface, v attestation.Verifier, ie utils.IdentityEvaluatorInterface, attestedData *protos.AttestedData, credentials *protos.Credentials) error {
 
 	// check that the enclave channelId matches ERCC channelId
 	if attestedData.CcParams.ChannelId != ctx.GetStub().GetChannelID() {
@@ -331,7 +331,7 @@ func checkAttestedData(ctx contractapi.TransactionContextInterface, v attestatio
 	}
 
 	// check that attestation evidence contains expectedMrEnclave as defined in chaincode definition
-	if err := v.VerifyEvidence(credentials.Evidence, credentials.SerializedAttestedData.Value, expectedMrEnclave); err != nil {
+	if err := v.VerifyCredentials(credentials, expectedMrEnclave); err != nil {
 		return fmt.Errorf("evidence verification failed: %s", err)
 	}
 

--- a/internal/attestation/conversion_test.go
+++ b/internal/attestation/conversion_test.go
@@ -10,13 +10,17 @@ package attestation
 import (
 	"testing"
 
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/simulation"
+
 	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
 	"github.com/hyperledger/fabric-private-chaincode/internal/utils"
 	"github.com/stretchr/testify/assert"
 )
 
-func NewDummyConverter() *Converter {
-	return &Converter{
+func NewDummyConverter() *types.Converter {
+	return &types.Converter{
 		Type: "dummy",
 		Converter: func(attestationBytes []byte) (evidenceBytes []byte, err error) {
 			return []byte("dummy evidence"), nil
@@ -26,9 +30,9 @@ func NewDummyConverter() *Converter {
 
 func TestDispatcher(t *testing.T) {
 
-	d := NewConverterDispatcher()
+	d := newConverterDispatcher()
 
-	attestation := &attestation{
+	attestation := &types.Attestation{
 		Type: "dummy",
 	}
 
@@ -52,7 +56,7 @@ func TestDispatcher(t *testing.T) {
 	assert.Error(t, err)
 
 	// but registering another converter should work fine
-	err = d.Register(NewSimulationConverter())
+	err = d.Register(simulation.NewSimulationConverter())
 	assert.NoError(t, err)
 }
 
@@ -65,7 +69,7 @@ func TestCredentialConverterWithSimulation(t *testing.T) {
 		Attestation: att,
 	}
 
-	cv := NewCredentialConverter()
+	cv := NewDefaultCredentialConverter()
 
 	serializedCredentials := utils.MarshallProtoBase64(credentials)
 	updatedSerializedCredentials, err := cv.ConvertCredentials(serializedCredentials)

--- a/internal/attestation/epid/converter.go
+++ b/internal/attestation/epid/converter.go
@@ -1,0 +1,52 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package epid
+
+import (
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	UnlinkableType = "epid-unlinkable"
+	LinkableType   = "epid-linkable"
+)
+
+// NewEpidUnlinkableConverter creates a new attestation converter for Intel SGX EPID (unlinkable) attestation
+func NewEpidUnlinkableConverter() *types.Converter {
+	return &types.Converter{
+		Type:      UnlinkableType,
+		Converter: newEpidConverter(),
+	}
+}
+
+// NewEpidLinkableConverter creates a new attestation converter for Intel SGX EPID (linkable) attestation
+func NewEpidLinkableConverter() *types.Converter {
+	return &types.Converter{
+		Type:      LinkableType,
+		Converter: newEpidConverter(),
+	}
+}
+
+func newEpidConverter() types.ConvertFunction {
+	return func(attestationBytes []byte) (evidenceBytes []byte, err error) {
+
+		apiKey, err := loadApiKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot load IAS API key")
+		}
+
+		ias := NewIASClient(apiKey)
+		evidence, err := ias.RequestAttestationReport(string(attestationBytes))
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot convert epid attestation")
+		}
+
+		return []byte(evidence), nil
+	}
+}

--- a/internal/attestation/epid/ias.go
+++ b/internal/attestation/epid/ias.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package epid
 
 import (
 	"bytes"

--- a/internal/attestation/epid/ias_test.go
+++ b/internal/attestation/epid/ias_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package epid
 
 import (
 	"encoding/base64"

--- a/internal/attestation/epid/pdo/interface.go
+++ b/internal/attestation/epid/pdo/interface.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package pdo
 
 type VerifierInterface interface {
 	VerifyEvidence(evidenceBytes, expectedStatementBytes []byte, expectedMrEnclave string) error

--- a/internal/attestation/epid/pdo/logging_cgo.go
+++ b/internal/attestation/epid/pdo/logging_cgo.go
@@ -8,7 +8,7 @@
    SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package pdo
 
 // extern void golog(char*);
 //

--- a/internal/attestation/epid/pdo/logging_go.go
+++ b/internal/attestation/epid/pdo/logging_go.go
@@ -8,14 +8,14 @@
    SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package pdo
 
 import (
 	"github.com/hyperledger/fabric/common/flogging"
 )
 
-// #cgo CFLAGS: -I${SRCDIR}/../../common/logging/untrusted
-// #cgo LDFLAGS: -L${SRCDIR}/../../common/logging/_build -lulogging
+// #cgo CFLAGS: -I${SRCDIR}/../../../../common/logging/untrusted
+// #cgo LDFLAGS: -L${SRCDIR}/../../../../common/logging/_build -lulogging
 // #include "logging.h"
 //
 // extern int golog_cgo_wrapper(const char* str);

--- a/internal/attestation/epid/utils.go
+++ b/internal/attestation/epid/utils.go
@@ -5,7 +5,7 @@ Copyright 2020 Intel Corporation
 SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package epid
 
 import (
 	"fmt"
@@ -16,40 +16,6 @@ import (
 
 	"github.com/pkg/errors"
 )
-
-// NewEpidUnlinkableConverter creates a new attestation converter for Intel SGX EPID (unlinkable) attestation
-func NewEpidUnlinkableConverter() *Converter {
-	return &Converter{
-		Type:      "epid-unlinkable",
-		Converter: newEpidConverter(),
-	}
-}
-
-// NewEpidLinkableConverter creates a new attestation converter for Intel SGX EPID (linkable) attestation
-func NewEpidLinkableConverter() *Converter {
-	return &Converter{
-		Type:      "epid-linkable",
-		Converter: newEpidConverter(),
-	}
-}
-
-func newEpidConverter() ConvertFunction {
-	return func(attestationBytes []byte) (evidenceBytes []byte, err error) {
-
-		apiKey, err := loadApiKey()
-		if err != nil {
-			return nil, errors.Wrap(err, "cannot load IAS API key")
-		}
-
-		ias := NewIASClient(apiKey)
-		evidence, err := ias.RequestAttestationReport(string(attestationBytes))
-		if err != nil {
-			return nil, errors.Wrap(err, "cannot convert epid attestation")
-		}
-
-		return []byte(evidence), nil
-	}
-}
 
 // loadApiKey tries to load the IAS API Key from environment variable.
 // If env var not set, use loadApiKeyFromCredentialsEnvPath and then loadApiKeyFromFPCConfig as fallback

--- a/internal/attestation/simulation/converter.go
+++ b/internal/attestation/simulation/converter.go
@@ -4,13 +4,20 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package attestation
+package simulation
+
+import (
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+)
+
+const SimulationType = "simulated"
 
 // NewSimulationConverter creates a new attestation converter for Intel SGX simulation mode
-func NewSimulationConverter() *Converter {
-	return &Converter{
-		Type: "simulated",
+func NewSimulationConverter() *types.Converter {
+	return &types.Converter{
+		Type: SimulationType,
 		Converter: func(attestationBytes []byte) (evidenceBytes []byte, err error) {
+			// NO-OP
 			return attestationBytes, nil
 		},
 	}

--- a/internal/attestation/simulation/issuer.go
+++ b/internal/attestation/simulation/issuer.go
@@ -1,0 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package simulation
+
+import "github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+
+// NewSimulationIssuer creates a new attestation issuer for Intel SGX simulation mode
+func NewSimulationIssuer() *types.Issuer {
+	return &types.Issuer{
+		Type:  SimulationType,
+		Issue: issue,
+	}
+}
+
+func issue(customData []byte) ([]byte, error) {
+	return []byte("{\"attestation_type\":\"" + SimulationType + "\",\"attestation\":\"MA==\"}"), nil
+}

--- a/internal/attestation/simulation/verifier.go
+++ b/internal/attestation/simulation/verifier.go
@@ -1,0 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package simulation
+
+import (
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+)
+
+func NewSimulationVerifier() *types.Verifier {
+	return &types.Verifier{
+		Type: SimulationType,
+		Verify: func(evidence *types.Evidence, expectedValidationValues *types.ValidationValues) (err error) {
+			// NO-OP
+			return nil
+		},
+	}
+}

--- a/internal/attestation/types/types.go
+++ b/internal/attestation/types/types.go
@@ -1,0 +1,44 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package types
+
+type ConvertFunction func(attestationBytes []byte) (evidenceBytes []byte, err error)
+
+type Converter struct {
+	Type      string
+	Converter ConvertFunction
+}
+
+type VerifyFunction func(evidence *Evidence, expectedValidationValues *ValidationValues) error
+
+type Verifier struct {
+	Type   string
+	Verify VerifyFunction
+}
+
+type IssueFunction func(customData []byte) ([]byte, error)
+
+type Issuer struct {
+	Type  string
+	Issue IssueFunction
+}
+
+type Attestation struct {
+	Type string `json:"attestation_type"`
+	Data string `json:"attestation"`
+}
+
+type Evidence struct {
+	Type string `json:"attestation_type"`
+	Data string `json:"evidence"`
+}
+
+type ValidationValues struct {
+	Statement []byte
+	Mrenclave string
+}

--- a/internal/attestation/verifier.go
+++ b/internal/attestation/verifier.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+	"github.com/hyperledger/fabric-private-chaincode/internal/protos"
+	"github.com/pkg/errors"
+)
+
+type verifierDispatcher struct {
+	verifiers map[string]types.VerifyFunction
+}
+
+func newVerifierDispatcher() *verifierDispatcher {
+	return &verifierDispatcher{
+		verifiers: make(map[string]types.VerifyFunction),
+	}
+}
+
+// Register adds new verifiers to the verifierDispatcher
+func (d *verifierDispatcher) Register(verifiers ...*types.Verifier) error {
+	for _, v := range verifiers {
+		if _, ok := d.verifiers[v.Type]; ok {
+			return fmt.Errorf("'%s' type is already registered", v.Type)
+		}
+		logger.Debugf("Register verifier of type '%s'", v.Type)
+		d.verifiers[v.Type] = v.Verify
+	}
+	return nil
+}
+
+func (d *verifierDispatcher) Verify(evidence *types.Evidence, expectedValidationValues *types.ValidationValues) error {
+	verify, ok := d.verifiers[evidence.Type]
+	if !ok {
+		return fmt.Errorf("'%s' type is not registered", evidence.Type)
+	}
+
+	logger.Debugf("Invoke verifier of type '%s'", evidence.Type)
+	return verify(evidence, expectedValidationValues)
+}
+
+type CredentialVerifier struct {
+	dispatcher *verifierDispatcher
+}
+
+type Verifier interface {
+	VerifyCredentials(credentials *protos.Credentials, expectedMrenclave string) (err error)
+}
+
+func NewCredentialVerifier(verifier ...*types.Verifier) *CredentialVerifier {
+	dispatcher := newVerifierDispatcher()
+	err := dispatcher.Register(verifier...)
+	if err != nil {
+		// ouch this should never happen
+		logger.Panicf("cannot create new credential converter! Reason: %s", err.Error())
+	}
+
+	return &CredentialVerifier{dispatcher: dispatcher}
+}
+
+func (c *CredentialVerifier) VerifyCredentials(credentials *protos.Credentials, expectedMrenclave string) error {
+
+	evidence, err := unmarshalEvidence(credentials.Evidence)
+	if err != nil {
+		return err
+	}
+
+	expectedValues := &types.ValidationValues{
+		Statement: credentials.SerializedAttestedData.Value,
+		Mrenclave: expectedMrenclave,
+	}
+
+	return c.dispatcher.Verify(evidence, expectedValues)
+}
+
+func unmarshalEvidence(serializedEvidence []byte) (*types.Evidence, error) {
+	att := &types.Evidence{}
+	err := json.Unmarshal(serializedEvidence, att)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot unmarshal evidence json")
+	}
+
+	return att, nil
+}

--- a/internal/attestation/verifier_test.go
+++ b/internal/attestation/verifier_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/simulation"
+	"github.com/hyperledger/fabric-private-chaincode/internal/attestation/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func NewDummyVerifier() *types.Verifier {
+	return &types.Verifier{
+		Type: "dummy",
+		Verify: func(evidence *types.Evidence, expectedValidationValues *types.ValidationValues) (err error) {
+			return nil
+		},
+	}
+}
+
+func TestVerifier(t *testing.T) {
+
+	d := newVerifierDispatcher()
+
+	ev := &types.Evidence{
+		Type: "dummy",
+	}
+
+	ref := &types.ValidationValues{
+		Statement: nil,
+		Mrenclave: "",
+	}
+
+	// should fail as no converter yet registered for type dummy
+	err := d.Verify(ev, ref)
+	assert.Error(t, err)
+
+	// register dummy converter
+	err = d.Register(NewDummyVerifier())
+	assert.NoError(t, err)
+
+	// conversion should now succeed
+	err = d.Verify(ev, ref)
+	assert.NoError(t, err)
+
+	// trying to register dummy again should fail as already registered
+	err = d.Register(NewDummyVerifier())
+	assert.Error(t, err)
+
+	// but registering another converter should work fine
+	err = d.Register(simulation.NewSimulationVerifier())
+	assert.NoError(t, err)
+}

--- a/utils/fabric/peer-cli-assist.src/peer-cli-assist.go
+++ b/utils/fabric/peer-cli-assist.src/peer-cli-assist.go
@@ -59,7 +59,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		converter := attestation.NewCredentialConverter()
+		converter := attestation.NewDefaultCredentialConverter()
 		credentialsStringOut, err := converter.ConvertCredentials(string(credentialsIn))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: couldn't convert credentials: %v\n", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enabled refactors the attestation component used in go. In particular, this refactoring is required to add DCAP-based attestation for FPC Go Chaincode. 
Additionally, this PR also upgrade the ego version.