### PR TITLE
Fix get_*_partial_state

### DIFF
--- a/ecc/chaincode/enclave/shim.go
+++ b/ecc/chaincode/enclave/shim.go
@@ -12,6 +12,7 @@ package enclave
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"sync"
 	"unsafe"
@@ -162,7 +163,7 @@ func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max
 		buf.WriteString("{\"key\":\"")
 		buf.WriteString(utils.TransformToFPCKey(item.Key))
 		buf.WriteString("\",\"value\":\"")
-		buf.Write(item.Value)
+		buf.WriteString(base64.StdEncoding.EncodeToString(item.Value))
 		if iter.HasNext() {
 			buf.WriteString("\"},")
 		} else {

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -192,7 +192,8 @@ int unmarshal_values(
     {
         JSON_Object* pair = json_array_get_object(pairs, i);
         const char* key = json_object_get_string(pair, "key");
-        const char* value = json_object_get_string(pair, "value");
+        const char* b64value = json_object_get_string(pair, "value");
+        std::string value = base64_decode(b64value);
         values.insert({key, value});
     }
     json_value_free(root);


### PR DESCRIPTION
**What this PR does / why we need it**:

When we call a `get_*_partial_state`, we fetch the data outside the enclave and wrap the entire result in a json message with the format [`key=value,...]`. Inside the enclave, we translate this json to `std::map<string, string>` and return it to the chaincode.

With non-public data, the values are encrypted and base64 encoded. That is, the json to map translation works as expected. However, for public data, where we handle arbitrary data, it seems that a value which contains a json string, will corrupt the json message and cannot be transformed into the map.

To fix this problem we do the following:
When creating the json message outside the enclave, we just take the value and encode it with base64 no matter if it is encrypted or not. After the translation into `std::map`, we just decode the value again. In case of encrypted values, we encode/decode twice and thereby increase payload size.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>

Thanks @lebdron for spotting this bug! The full discussion about this error can be found on [discord](https://discord.com/channels/905194001349627914/943059293765267497/962989270329602078).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

