### PR TITLE
Fix shim.go link in readme

### DIFF
--- a/ecc_go/README.md
+++ b/ecc_go/README.md
@@ -19,7 +19,7 @@ In particular, it contains:
 
 We aim to support Go Chaincode without the need to refactor existing code but still benefit from the security properties added by FPC.
 However, we currently support only a limited Chaincode API with common functionality to enable a broad set of applications.
-We refer to [shim.go](ecc_go/chaincode/enclave_go/shim.go) for the full list of supported functions.
+We refer to [shim.go](chaincode/enclave_go/shim.go) for the full list of supported functions.
 Note that calling unsupported shim functions, currently results in a `panic`.
 
 To use FPC, you simply need to wrap your chaincode with the FPC Go Library. Here an example:


### PR DESCRIPTION
Signed-off-by: munapower <mmunaro@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
Fixes a link in readme documentation of go support preview that instead of taking you to shim.go returns a 404 error.
```
