### PR TITLE
Go upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Make sure that you have the following required dependencies installed:
 
 * CMake v3.5.1 or higher
 
-* [Go](https://golang.org/) 1.16.7 or higher
+* [Go](https://golang.org/) 1.17.5 or higher
 
 * Docker 18.09 (or higher) and docker-compose 1.25.x (or higher)
   Note that version from Ubuntu 18.04 is not recent enough!  To upgrade, install a recent version following the instructions from [docker.com](https://docs.docker.com/compose/install/), e.g., for version 1.25.4 execute	

--- a/ecc/chaincode/enclave/enclave.go
+++ b/ecc/chaincode/enclave/enclave.go
@@ -1,3 +1,4 @@
+//go:build !mock_ecc
 // +build !mock_ecc
 
 /*

--- a/ecc/chaincode/enclave/logging_cgo.go
+++ b/ecc/chaincode/enclave/logging_cgo.go
@@ -1,3 +1,4 @@
+//go:build !mock_ecc
 // +build !mock_ecc
 
 /*

--- a/ecc/chaincode/enclave/logging_go.go
+++ b/ecc/chaincode/enclave/logging_go.go
@@ -1,3 +1,4 @@
+//go:build !mock_ecc
 // +build !mock_ecc
 
 /*

--- a/ecc/chaincode/enclave/mock_enclave.go
+++ b/ecc/chaincode/enclave/mock_enclave.go
@@ -1,3 +1,4 @@
+//go:build mock_ecc
 // +build mock_ecc
 
 /*

--- a/ecc/chaincode/enclave/shim.go
+++ b/ecc/chaincode/enclave/shim.go
@@ -1,3 +1,4 @@
+//go:build !mock_ecc
 // +build !mock_ecc
 
 /*

--- a/ercc/attestation/logging_cgo.go
+++ b/ercc/attestation/logging_cgo.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/ercc/attestation/logging_go.go
+++ b/ercc/attestation/logging_go.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/ercc/attestation/verifier.go
+++ b/ercc/attestation/verifier.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/internal/crypto/compatibility_test/compatibility_test.go
+++ b/internal/crypto/compatibility_test/compatibility_test.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/internal/crypto/crypto_pdo.go
+++ b/internal/crypto/crypto_pdo.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/internal/crypto/crypto_pdo_test.go
+++ b/internal/crypto/crypto_pdo_test.go
@@ -1,3 +1,4 @@
+//go:build WITH_PDO_CRYPTO
 // +build WITH_PDO_CRYPTO
 
 /*

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -20,7 +20,7 @@ ARG FPC_VERSION=main
 FROM hyperledger/fabric-private-chaincode-base-rt:${FPC_VERSION} as common
 
 # config/build params
-ARG GO_VERSION=1.16.7
+ARG GO_VERSION=1.17.5
 ARG NANOPB_VERSION=0.4.3
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g

--- a/utils/tools.go
+++ b/utils/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
Current build fails to an incompatibility of one of our go tools.

This PR upgrade to go 1.17.5, which is currently also used by Fabric. 