### PR TITLE
Fix README.md for make docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,11 +363,13 @@ Note by default we build FPC with SGX simulation mode. For SGX hardware-mode sup
 To build all required FPC components and run the integration tests run the following:
 ```bash
 cd $FPC_PATH
+make docker
 make
  ```
 
 Besides the default target, there are also following make targets:
 - `build`: build all FPC build artifacts
+- `docker`: build docker images 
 - `test`: run unit and integration tests
 - `clean`: remove most build artifacts (but no docker images)
 - `clobber`: remove all build artifacts including built docker images


### PR DESCRIPTION
**What this PR does / why we need it**:

When building FPC, We need to enter the fpc-development-main container and run `make`.
In that case, We need to run `make docker` before running `make`, otherwise We will get an error, so I modified the README.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:

No


Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>
