### PR TITLE
Fix path to SGX hardware

### DIFF
--- a/integration/go_chaincode/utils/utils.go
+++ b/integration/go_chaincode/utils/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 func DetectSgxDevicePath() (string, error) {
-	possiblePaths := []string{"/dev/isgx", "dev/sgx/enclave"}
+	possiblePaths := []string{"/dev/isgx", "/dev/sgx/enclave"}
 	for _, p := range possiblePaths {
 		if _, err := os.Stat(p); err != nil {
 			continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

An error occurred when performing a FPC build in the go-support-preview branch on a DCsv2 instance of Microsoft Azure.
I fixed it because the way the path to the SGX hardware in `integration/go_chaincode/utils/utils.go` was written was not an absolute path.


**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

Signed-off-by: ikegawa-koshi <koshi.ikegawa.mf@hitachi.com>