### PR TITLE
Fix staticcheck version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ gotools:
 	$(GO) install golang.org/x/tools/cmd/goimports
 	$(GO) install google.golang.org/protobuf/cmd/protoc-gen-go
 	GO111MODULE=off $(GO) get github.com/maxbrunsfeld/counterfeiter
-	$(GO) install honnef.co/go/tools/cmd/staticcheck@latest
+	$(GO) install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 	$(GO) get -u github.com/client9/misspell/cmd/misspell
 
 godeps: gotools

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -76,7 +76,7 @@ ENV PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
 RUN  go get golang.org/x/tools/cmd/goimports \
   && go get google.golang.org/protobuf/cmd/protoc-gen-go \
   && GO111MODULE=off go get github.com/maxbrunsfeld/counterfeiter \
-  && go get honnef.co/go/tools/cmd/staticcheck \
+  && go get honnef.co/go/tools/cmd/staticcheck@v0.3.3 \
   && go get github.com/client9/misspell/cmd/misspell \
   && GO111MODULE=on go get github.com/mikefarah/yq/v3
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The version of `honnef.co/go/tools/cmd/staticcheck` has been updated to v0.4 series and the required version of golang is v1.19.
To work with golang v1.17, the version of `staticcheck` needs to be fixed to v0.3 series.
This pull request fixes the above problem in the base-dev Dockerfile.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

