### PR TITLE
Resolves #693, upgrade ego to v1.3

### DIFF
--- a/ecc_go/README.md
+++ b/ecc_go/README.md
@@ -80,8 +80,8 @@ Install ego by running the following:
 ```bash
 wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add
 add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
-wget https://github.com/edgelesssys/ego/releases/download/v1.2.0/ego_1.2.0_amd64.deb
-apt install ./ego_1.2.0_amd64.deb build-essential libssl-dev
+wget https://github.com/edgelesssys/ego/releases/download/v1.3.0/ego_1.3.0_amd64.deb
+apt install ./ego_1.3.0_amd64.deb build-essential libssl-dev
 ```
 
 You can find more information about ego installation on the official [documentation](https://docs.edgeless.systems/ego/#/getting-started/install).

--- a/ecc_go/README.md
+++ b/ecc_go/README.md
@@ -80,8 +80,8 @@ Install ego by running the following:
 ```bash
 wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add
 add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
-wget https://github.com/edgelesssys/ego/releases/download/v1.0.0/ego_1.0.0_amd64.deb
-apt install ./ego_1.0.0_amd64.deb build-essential libssl-dev
+wget https://github.com/edgelesssys/ego/releases/download/v1.2.0/ego_1.2.0_amd64.deb
+apt install ./ego_1.2.0_amd64.deb build-essential libssl-dev
 ```
 
 You can find more information about ego installation on the official [documentation](https://docs.edgeless.systems/ego/#/getting-started/install).

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -26,7 +26,7 @@ ARG NANOPB_VERSION=0.4.7
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 ARG APT_ADD_PKGS=
-ARG EGO_VERSION=1.2.0
+ARG EGO_VERSION=1.3.0
 
 # for convenience remember all versions as env variables ..
 ENV GO_VERSION=${GO_VERSION}

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -26,7 +26,7 @@ ARG NANOPB_VERSION=0.4.7
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 ARG APT_ADD_PKGS=
-ARG EGO_VERSION=1.0.0
+ARG EGO_VERSION=1.2.0
 
 # for convenience remember all versions as env variables ..
 ENV GO_VERSION=${GO_VERSION}


### PR DESCRIPTION
What this PR does / why we need it:
Upgrade ego to v1.3, current ego version is v1.0

Which issue(s) this PR fixes:

Fixes https://github.com/hyperledger/fabric-private-chaincode/issues/693

Special notes for your reviewer:
Successfully build docker-dev in local

can build local dev and test ego using the code below
```
cd $FPC_PATH/utils/docker
make build-dev
make run-dev
```

Here is the result:
```
root@docker-desktop:/project/src/github.com/hyperledger/fabric-private-chaincode# ego
EGo v1.3.0 (360a6a40836461465fdbd0742dfb0f980b68c638)
Manage and run EGo enclaves.
...
```