### PR TITLE
Upgrade docker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: build dev image
         env:
-          DOCKER_BUILDKIT: 1
           DOCKER_QUIET_BUILD: 1
         run: |
           DOCKER_BUILD_OPTS="--build-arg UBUNTU_VERSION=${{ matrix.os-version }} --build-arg UBUNTU_NAME=${{ matrix.os-name }}" \
@@ -31,7 +30,6 @@ jobs:
       - name: run make inside dev container
         env:
           DOCKER_DEV_CI_MODE: 1
-          DOCKER_BUILDKIT: 1
           DOCKER_QUIET_BUILD: 1
         run: |
           DOCKER_DEV_RUN_OPTS=`bash <(curl -s https://codecov.io/env)` \

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ official docker [documentation](https://docs.docker.com/install/linux/linux-post
 for more details.
 
 First make sure your host has
-* Docker 18.09 (or higher).
+* Docker v23.0 (or higher).
   It also should use `/var/run/docker.sock` as socket to interact with the daemon (or you
   will have to override in `$FPC_PATH/config.override.mk` the default definition in make of `DOCKER_DAEMON_SOCKET`)
 * GNU make

--- a/build.mk
+++ b/build.mk
@@ -8,7 +8,7 @@ include $(TOP)/config.mk
 -include $(TOP)/config.override.mk
 
 # define composites only here and not in config.mk so we can override parts in config.override.mk
-DOCKER := DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) $(DOCKER_CMD) $(DOCKERFLAGS)
+DOCKER := $(DOCKER_CMD) $(DOCKERFLAGS)
 ifeq (${SGX_MODE}, HW)
 	GOTAGS = -tags sgx_hw_mode
 endif

--- a/config.mk
+++ b/config.mk
@@ -14,10 +14,6 @@ export GO_BUILD_OPT ?= -buildvcs=false
 
 # Docker related settings
 #--------------------------------------------------
-export DOCKER_BUILDKIT ?= 1
-# Building with build-kit makes multi-stage builds more efficient
-# and also provides nicer output. If you experience issues with build-kit,
-# you can disable it by overriding the default in your `config.override.mk`
 DOCKERFLAGS :=
 DOCKER_CMD := docker
 # Note:

--- a/samples/demos/irb/experimenter/Makefile
+++ b/samples/demos/irb/experimenter/Makefile
@@ -11,7 +11,7 @@ protos:
 	$(MAKE) -C ../protos
 
 build: protos
-	DOCKER_BUILDKIT=0 docker build -f Dockerfile -t irb-experimenter-worker ..
+	docker build -f Dockerfile -t irb-experimenter-worker ..
 
 run: build
 	$(MAKE) -C worker stop-docker run-docker

--- a/samples/deployment/azure/FPC_on_Azure.md
+++ b/samples/deployment/azure/FPC_on_Azure.md
@@ -77,7 +77,7 @@ echo 'epid-unlinkable' > ${FPC_PATH}/config/ias/spid_type.txt
 
 There are two methods of setting up the FPC development environment.
 The [docker based](../../../README.md#option-1-using-the-docker-based-fpc-development-environment) environment which is used here, and the [local development](../../../README.md#option-2-setting-up-your-system-to-do-local-development) environment.
-Edit the `config.override.mk`  to set HW mode and `DOCKER_BUILDKIT=1`.
+Edit the `config.override.mk`  to set HW mode.
 ```bash
 vim $FPC_PATH/config.override.mk
 ```
@@ -85,7 +85,6 @@ vim $FPC_PATH/config.override.mk
 paste in the following:
 ```bash
 export SGX_MODE=HW
-export DOCKER_BUILDKIT=1
 ```
 
 Now we can start the container as follows:

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -54,13 +54,21 @@ RUN apt-get update -q \
     python \
     protobuf-compiler \
     python-protobuf \
-    # docker commands (need as we use docker daemon from "outside")
-    docker.io \
-    docker-compose \
     psmisc \
     bc \
+    software-properties-common \
     ${APT_ADD_PKGS}
 
+# docker commands (need as we use docker daemon from "outside")
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+  && add-apt-repository "deb [arch="$(dpkg --print-architecture)"] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" \
+  && apt-get update -q \
+  && apt-get install -y -q \
+    # docker-ce \
+    docker-ce-cli \
+    # containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
 
 # Install go
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
- As docker uses BuildKit by default, we can remove the explicit `DOCKER_BUILDKIT=1`. 
- Install docker from docker.com instead via outdated apt distro repo as this included the buildkit plugin