### PR TITLE
Upgrade yq from v3.x to v4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Make sure that you have the following required dependencies installed:
 * yq v3.x (newer versions, v4.x and higher, are currently *not* supported!)
   You can install `yq` v3 via `go get`.
   ```bash
-  GO111MODULE=on go get github.com/mikefarah/yq/v3
+    GO111MODULE=on go get github.com/mikefarah/yq/v4
   ```
 
 * Protocol Buffers

--- a/samples/deployment/fabric-smart-client/the-simple-testing-network/env.sh
+++ b/samples/deployment/fabric-smart-client/the-simple-testing-network/env.sh
@@ -32,9 +32,9 @@ if [[ ! -f "$GATEWAY_CONFIG" ]]; then
     exit 1
 fi
 
-MSP_ID=$(yq r $GATEWAY_CONFIG organizations.${ORG^}.mspid)
-PEER_ID=$(yq r $GATEWAY_CONFIG organizations.${ORG^}.peers[0])
-ADDR=$(yq r $GATEWAY_CONFIG peers.\"${PEER_ID}\".url | sed 's/grpcs:\/\///')
+MSP_ID=$(yq e ".organizations.${ORG^}.mspid" $GATEWAY_CONFIG)
+PEER_ID=$(yq e ".organizations.${ORG^}.peers[0]" $GATEWAY_CONFIG)
+ADDR=$(yq e ".peers.\"${PEER_ID}\".url" $GATEWAY_CONFIG | sed 's/grpcs:\/\///')
 
 echo "export CONF_PATH=$FPC_PATH/samples/deployment/fabric-smart-client/the-simple-testing-network/testdata/fabric.default/crypto" > ${ORG}.env
 echo "export GATEWAY_CONFIG=\$CONF_PATH/peerOrganizations/${ORG,,}.example.com/connections.yaml" >> ${ORG}.env

--- a/samples/deployment/fabric-smart-client/the-simple-testing-network/env.sh
+++ b/samples/deployment/fabric-smart-client/the-simple-testing-network/env.sh
@@ -32,9 +32,9 @@ if [[ ! -f "$GATEWAY_CONFIG" ]]; then
     exit 1
 fi
 
-MSP_ID=$(yq e ".organizations.${ORG^}.mspid" $GATEWAY_CONFIG)
-PEER_ID=$(yq e ".organizations.${ORG^}.peers[0]" $GATEWAY_CONFIG)
-ADDR=$(yq e ".peers.\"${PEER_ID}\".url" $GATEWAY_CONFIG | sed 's/grpcs:\/\///')
+MSP_ID=$(yq ".organizations.${ORG^}.mspid" "$GATEWAY_CONFIG")
+PEER_ID=$(yq ".organizations.${ORG^}.peers[0]" "$GATEWAY_CONFIG")
+ADDR=$(yq ".peers.\"${PEER_ID}\".url" "$GATEWAY_CONFIG" | sed 's/grpcs:\/\///')
 
 echo "export CONF_PATH=$FPC_PATH/samples/deployment/fabric-smart-client/the-simple-testing-network/testdata/fabric.default/crypto" > ${ORG}.env
 echo "export GATEWAY_CONFIG=\$CONF_PATH/peerOrganizations/${ORG,,}.example.com/connections.yaml" >> ${ORG}.env

--- a/samples/deployment/test-network/setup.sh
+++ b/samples/deployment/test-network/setup.sh
@@ -80,8 +80,8 @@ sed -i "s+\.\./+${FABRIC_SAMPLES_HOST}/test-network/+g" "${DOCKER_COMPOSE_CA}"
 echo "${DOCKER_COMPOSE_TEST_NET}"
 peers=("peer0.org1.example.com" "peer0.org2.example.com")
 for p in "${peers[@]}"; do
-  yq eval ".services.\"$p\".volumes += [\"${FPC_PATH_HOST}:/opt/gopath/src/github.com/hyperledger/fabric-private-chaincode\"]" ${DOCKER_COMPOSE_TEST_NET} -i
-  yq eval ".services.\"$p\".volumes += [\"${FABRIC_SAMPLES_HOST}/config/core.yaml:/etc/hyperledger/fabric/core.yaml\"]" ${DOCKER_COMPOSE_TEST_NET} -i
+  yq ".services.\"$p\".volumes += [\"${FPC_PATH_HOST}:/opt/gopath/src/github.com/hyperledger/fabric-private-chaincode\"]" -i "${DOCKER_COMPOSE_TEST_NET}"
+  yq ".services.\"$p\".volumes += [\"${FABRIC_SAMPLES_HOST}/config/core.yaml:/etc/hyperledger/fabric/core.yaml\"]" -i "${DOCKER_COMPOSE_TEST_NET}"
 done
 
 ###############################################

--- a/samples/deployment/test-network/setup.sh
+++ b/samples/deployment/test-network/setup.sh
@@ -44,7 +44,7 @@ fi
 echo "Adding FPC external builder to core.yaml"
 # Create a backup copy of `core.yaml` first and always work from there.
 backup ${CORE_PATH}
-yq m -i -a=append ${CORE_PATH} core_ext.yaml
+yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' ${CORE_PATH} core_ext.yaml -i
 
 
 ###############################################
@@ -80,8 +80,8 @@ sed -i "s+\.\./+${FABRIC_SAMPLES_HOST}/test-network/+g" "${DOCKER_COMPOSE_CA}"
 echo "${DOCKER_COMPOSE_TEST_NET}"
 peers=("peer0.org1.example.com" "peer0.org2.example.com")
 for p in "${peers[@]}"; do
-  yq w -i ${DOCKER_COMPOSE_TEST_NET} "services.\"$p\".volumes[+]" "${FPC_PATH_HOST}:/opt/gopath/src/github.com/hyperledger/fabric-private-chaincode"
-  yq w -i ${DOCKER_COMPOSE_TEST_NET} "services.\"$p\".volumes[+]" "${FABRIC_SAMPLES_HOST}/config/core.yaml:/etc/hyperledger/fabric/core.yaml"
+  yq eval ".services.\"$p\".volumes += [\"${FPC_PATH_HOST}:/opt/gopath/src/github.com/hyperledger/fabric-private-chaincode\"]" ${DOCKER_COMPOSE_TEST_NET} -i
+  yq eval ".services.\"$p\".volumes += [\"${FABRIC_SAMPLES_HOST}/config/core.yaml:/etc/hyperledger/fabric/core.yaml\"]" ${DOCKER_COMPOSE_TEST_NET} -i
 done
 
 ###############################################

--- a/samples/deployment/test-network/setup.sh
+++ b/samples/deployment/test-network/setup.sh
@@ -44,7 +44,7 @@ fi
 echo "Adding FPC external builder to core.yaml"
 # Create a backup copy of `core.yaml` first and always work from there.
 backup ${CORE_PATH}
-yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' ${CORE_PATH} core_ext.yaml -i
+yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' -i ${CORE_PATH} core_ext.yaml
 
 
 ###############################################

--- a/samples/deployment/test-network/update-connection.sh
+++ b/samples/deployment/test-network/update-connection.sh
@@ -46,7 +46,7 @@ for org in "${orgs[@]}"; do
   CERTS=("${ORG_PATH}/users/${user}@${org}.example.com/msp/signcerts"/*.pem)
   KEYS=("${ORG_PATH}/users/${user}@${org}.example.com/msp/keystore"/*)
 
-  
+  # add cryptopath and admin cert / key
   yq ".organizations.${org^}.cryptoPath = \"${ORG_PATH}/msp\"" -i "${CONNECTIONS_PATH}"
   yq ".organizations.${org^}.users.${user}.cert.path = \"${CERTS[0]}\"" -i "${CONNECTIONS_PATH}"
   yq ".organizations.${org^}.users.${user}.key.path = \"${KEYS[0]}\"" -i "${CONNECTIONS_PATH}"

--- a/samples/deployment/test-network/update-connection.sh
+++ b/samples/deployment/test-network/update-connection.sh
@@ -81,7 +81,7 @@ done
 
 # consolidate all collected peers in a single peers.yaml
 yq eval-all '. as $item ireduce ({}; . * $item )' ${tmp_dir}/peers-*.yaml >> "${tmp_dir}/peers.yaml"
-yq 'true' "${tmp_dir}/peers-${org}.yaml" > /dev/null
+yq 'true' "${tmp_dir}/peers.yaml" > /dev/null
 
 # merge peers.yaml into all connection files
 for org in "${orgs[@]}"; do

--- a/samples/deployment/test-network/update-connection.sh
+++ b/samples/deployment/test-network/update-connection.sh
@@ -47,12 +47,13 @@ for org in "${orgs[@]}"; do
   KEYS=("${ORG_PATH}/users/${user}@${org}.example.com/msp/keystore"/*)
 
   # add cryptopath and admin cert / key
-  yq w -i ${CONNECTIONS_PATH} organizations.${org^}.cryptoPath ${ORG_PATH}/msp
-  yq w -i ${CONNECTIONS_PATH} organizations.${org^}.users.${user}.cert.path "${CERTS[0]}"
-  yq w -i ${CONNECTIONS_PATH} organizations.${org^}.users.${user}.key.path "${KEYS[0]}"
+  yq eval ".organizations.${org^}.cryptoPath = \"${ORG_PATH}/msp\"" ${CONNECTIONS_PATH} -i
+  yq eval ".organizations.${org^}.users.${user}.cert.path = \"${CERTS[0]}\"" ${CONNECTIONS_PATH} -i
+  yq eval ".organizations.${org^}.users.${user}.key.path = \"${KEYS[0]}\"" ${CONNECTIONS_PATH} -i
 
   # add channels and entity matcher
-  yq m -i ${CONNECTIONS_PATH} - <<EOF
+  yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' ${CONNECTIONS_PATH} -i <<EOF
+
 channels:
   _default:
     peers:
@@ -75,19 +76,19 @@ entityMatchers:
 EOF
 
   # fetch all peers from connections
-  yq r --printMode pv "${CONNECTIONS_PATH}" peers >> "${tmp_dir}/peers-${org}.yaml"
+  yq e ".peers" "${CONNECTIONS_PATH}" >> "${tmp_dir}/peers-${org}.yaml"
 done
 
 # consolidate all collected peers in a single peers.yaml
-yq m "${tmp_dir}"/peers-*.yaml >> "${tmp_dir}/peers.yaml"
-yq v "${tmp_dir}/peers.yaml"
+yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' "${tmp_dir}"/peers-*.yaml >> "${tmp_dir}/peers.yaml"
+yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' "${CONNECTIONS_PATH}" "${tmp_dir}/peers.yaml" -i
 
 # merge peers.yaml into all connection files
 for org in "${orgs[@]}"; do
   ORG_PATH="${FPC_PATH}/samples/deployment/test-network/fabric-samples/test-network/organizations/peerOrganizations/${org}.example.com"
   CONNECTIONS_PATH="${ORG_PATH}/connection-${org}.yaml"
-  yq m -i "${CONNECTIONS_PATH}" "${tmp_dir}/peers.yaml"
-  yq v "${CONNECTIONS_PATH}"
+  yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' "${tmp_dir}"/peers-*.yaml >> "${tmp_dir}/peers.yaml"
+  yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' "${CONNECTIONS_PATH}" "${tmp_dir}/peers.yaml" -i
 done
 
 echo "Updated!"

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -86,7 +86,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest \
   && go install github.com/maxbrunsfeld/counterfeiter/v6@latest \
   && go install honnef.co/go/tools/cmd/staticcheck@2023.1.3 \
   && go install github.com/client9/misspell/cmd/misspell@latest \
-  && go get github.com/mikefarah/yq/v4@latest
+  && go install github.com/mikefarah/yq/v4@latest
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -86,7 +86,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest \
   && go install github.com/maxbrunsfeld/counterfeiter/v6@latest \
   && go install honnef.co/go/tools/cmd/staticcheck@2023.1.3 \
   && go install github.com/client9/misspell/cmd/misspell@latest \
-  && go install github.com/mikefarah/yq/v3@latest
+  && go get github.com/mikefarah/yq/v4@latest
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -182,6 +182,6 @@ RUN apt-get install -y -q \
 	${APT_ADD_PKGS}
 
 RUN GO111MODULE=on \
-    go get github.com/mikefarah/yq/v3
+  go get github.com/mikefarah/yq/v4
 
 WORKDIR ${FPC_PATH}


### PR DESCRIPTION
Some example scripts still use an older version of yq. To run the example scripts properly newer version of yq is added.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**: Upgrades the yq V3.x to yq v4.x

**Which issue(s) this PR fixes**:
- upgrades the yq from v3.x to v4.x 
- updates the yq codes in the list of files below :
 - `./samples/deployment/test-network/setup.sh`
 - `./samples/deployment/fabric-smart-client/the-simple-testing-network/env.sh`
 - `./samples/deployment/test-network/update-connection.sh`
 - `./samples/deployment/test-network/fabric-samples/test-network-nano-bash/README.md`
 -  `./README.md`
 - `./utils/docker/dev_peer_cc-builder/Dockerfile`
 - `./utils/docker/base-dev/Dockerfile`

Fixes #719 
