### PR TITLE
Remove loading docker config inside dev container

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A few more notes:
   DOCKER_BUILD_OPTS=--build-arg UBUNTU_VERSION=18.04 --build-arg UBUNTU_NAME=bionic
   ```
 * If you run behind a proxy, you will have to configure the proxy,
-  e.g., for docker (`~/.docker/config.json`). See
+  e.g., for docker (`~/.docker/config.json`) and load the configuration inside the dev container by setting `DOCKER_DEV_RUN_OPTS += -v "~/.docker":"/root/.docker"` in `$FPC_PATH/config.override.mk`. See
   [Working from behind a proxy](#working-from-behind-a-proxy) below for more information.
 * If your local host is SGX enabled, i.e., there is a device `/dev/sgx/enclave` or
   `/dev/isgx` and your PSW daemon listens to `/var/run/aesmd`, then the docker image will be sgx-enabled and your settings from `./config/ias` will be used. You will have to manually set `SGX_MODE=HW` before building anything to use HW mode.

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ A few more notes:
   DOCKER_BUILD_OPTS=--build-arg UBUNTU_VERSION=18.04 --build-arg UBUNTU_NAME=bionic
   ```
 * If you run behind a proxy, you will have to configure the proxy,
-  e.g., for docker (`~/.docker/config.json`) and load the configuration inside the dev container by setting `DOCKER_DEV_RUN_OPTS += -v "~/.docker":"/root/.docker"` in `$FPC_PATH/config.override.mk`. See
-  [Working from behind a proxy](#working-from-behind-a-proxy) below for more information.
+  e.g., for docker (`~/.docker/config.json`) and load the configuration inside the dev container by setting `DOCKER_DEV_RUN_OPTS += -v "$HOME/.docker":"/root/.docker"` in `$FPC_PATH/config.override.mk`.
+  See [Working from behind a proxy](#working-from-behind-a-proxy) below for more information. Also note that with newer docker versions (i.e., docker desktop), the docker socket is located on the host in `~/.docker/`. This may cause issues when using docker inside the FPC dev container as the docker client is not able to access the docker socket at the path of the host system. You may try to switch the docker context to use `/var/run/docker.sock`. We do not recommend this approach and happy for suggestions.
 * If your local host is SGX enabled, i.e., there is a device `/dev/sgx/enclave` or
   `/dev/isgx` and your PSW daemon listens to `/var/run/aesmd`, then the docker image will be sgx-enabled and your settings from `./config/ias` will be used. You will have to manually set `SGX_MODE=HW` before building anything to use HW mode.
 * If you want additional apt packages to be automatically added to your

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -85,10 +85,6 @@ DOCKER_DEV_RUN_OPTS ?=
 DOCKER_DEV_RUN_OPTS += --rm
 # - import docker daemon socket (so dev container can run docker)
 DOCKER_DEV_RUN_OPTS += -v "$(DOCKER_DAEMON_SOCKET)":"$(DOCKER_SOCKET)"
-# - if ~/.docker/ exists, pass it also along to container so we have consistent config
-ifneq ($(wildcard ${HOME}/.docker),)
-DOCKER_DEV_RUN_OPTS += -v "${HOME}/.docker":"/root/.docker"
-endif
 # - mount local fpc repo into the dev container so development inside container is
 #   persistant (and also can be done from outside with whatever favorite IDE ...)
 DOCKER_DEV_RUN_OPTS += -v "$(abspath ${TOP})":$(DOCKER_FPC_PATH)


### PR DESCRIPTION
With recent versions of Docker Desktop (and others Rancher Desktop), the docker configuration loaded into the dev container can not resolve the path to the docker socket. We let users the option to mount the docker configuration inside the container if needed.

This PR fixes #715