### PR TITLE
SGX upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            os-version: 20.04
-            os-name: focal
+          - os: ubuntu-22.04
+            os-version: 22.04
+            os-name: jammy
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Note that by default the dev container mounts your local cloned FPC project as a
 This allows you to edit the content of the repository using your favorite editor in your system and the changes inside the docker container. Additionally, you are also not loosing changes inside the container when you reboot or the container gets stopped for other reasons.
 
 A few more notes:
-* We use Ubuntu 20.04 by default.
-  To build also docker images based on Ubuntu 18.04, add the following to `$FPC_PATH/config.override.mk`.
+* We use Ubuntu 22.04 by default.
+  To build also docker images with a different version of Ubuntu, add the following to `$FPC_PATH/config.override.mk`.
   ```bash
   DOCKER_BUILD_OPTS=--build-arg UBUNTU_VERSION=18.04 --build-arg UBUNTU_NAME=bionic
   ```
@@ -255,7 +255,7 @@ As an alternative to the Docker-based FPC development environment you can instal
 #### Requirements
 
 Make sure that you have the following required dependencies installed:
-* Linux (OS) (we recommend Ubuntu 20.04, see [list](https://github.com/intel/linux-sgx#prerequisites) supported OS)
+* Linux (OS) (we recommend Ubuntu 22.04, see [list](https://github.com/intel/linux-sgx#prerequisites) supported OS)
 
 * CMake v3.5.1 or higher
 
@@ -274,23 +274,23 @@ Make sure that you have the following required dependencies installed:
   sudo chmod +x /usr/local/bin/docker-compose
   ``` 
 
-* yq v3.x (newer versions, v4.x and higher, are currently *not* supported!)
-  You can install `yq` v3 via `go get`.
+* yq v4.x
+  You can install `yq` via `go get`.
   ```bash
-    GO111MODULE=on go get github.com/mikefarah/yq/v4
+    go get github.com/mikefarah/yq/v4
   ```
 
 * Protocol Buffers
     - Protocol Buffers 3.0.x needed for the Intel SGX SDK
     - Protocol Buffers 3.11.x or higher and [Nanopb](http://github.com/nanopb/nanopb) 0.4.7
 
-* SGX PSW & SDK v2.12 for [Linux](https://01.org/intel-software-guard-extensions/downloads)
+* SGX PSW & SDK v2.22 for [Linux](https://01.org/intel-software-guard-extensions/downloads)
   (alternatively, you could also install it from the [source](https://github.com/intel/linux-sgx)
 
 * Credentials for Intel Attestation Service, read [here](#intel-attestation-service-ias) (for hardware-mode SGX)
 
 * [Intel Software Guard Extensions SSL](https://github.com/intel/intel-sgx-ssl)
-  (we recommend using branch `lin_2.10_1.1.1g` OpenSSL `1.1.1g`)
+  (we recommend using tag `3.0_Rev2` OpenSSL `3.0.12`)
 
 * Hyperledger [Fabric](https://github.com/hyperledger/fabric/tree/v2.5.4) v2.5.4
 
@@ -326,7 +326,7 @@ are set correctly in your environment.
 
 We use *nanopb*, a lightweight implementation of Protocol Buffers, inside the enclaves to parse blocks of
 transactions. Install nanopb by following the instruction below. For this you need a working Google Protocol Buffers
-compiler with python bindings (e.g. via `apt-get install protobuf-compiler python-protobuf libprotobuf-dev`).
+compiler with python bindings (e.g. via `apt-get install protobuf-compiler python3-protobuf libprotobuf-dev`).
 For more detailed information consult the official nanopb documentation http://github.com/nanopb/nanopb.
 ```bash
 export NANOPB_PATH=/path-to/install/nanopb/
@@ -341,8 +341,8 @@ Make sure that you set `$NANOPB_PATH` as it is needed to build Fabric Private Ch
 Moreover, in order to build Fabric protobufs we also require a newer Protobuf compiler than what is provided as standard Ubuntu package and is used to build the
 Intel SGX SDK. For this reason you will have to download and install another version and use it together with Nanopb. Do not install the new protobuf, though, such that it is not found in your standard PATH but instead define the `PROTOC_CMD`, either as environment variable or via `config.override.mk` to point to the new `protoc` binary
 ```bash
-wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip
-unzip protoc-3.11.4-linux-x86_64.zip -d /usr/local/proto3
+wget https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
+unzip protoc-22.3-linux-x86_64.zip -d /usr/local/proto3
 export PROTOC_CMD=/usr/local/proto3/bin/protoc
 ```
 
@@ -444,7 +444,7 @@ Note that this is indented for developing purpose only and does not provide any 
 
 In your `config.override.mk` set the following to variables:
 ```Makefile
-FPC_CCENV_IMAGE=ubuntu:20.04
+FPC_CCENV_IMAGE=ubuntu:22.04
 ERCC_GOTAGS=
 ```
 This configuration sets a standard Ubuntu image as alternative to our `fabric-private-chaincode-ccenv` image and overrides the default build tags we use to build `ercc`.

--- a/build.mk
+++ b/build.mk
@@ -4,7 +4,7 @@
 
 include $(TOP)/config.mk
 
-# optionlly allow local overriding defaults
+# optionally allow local overriding defaults
 -include $(TOP)/config.override.mk
 
 # define composites only here and not in config.mk so we can override parts in config.override.mk
@@ -17,9 +17,7 @@ GO := $(GO_CMD) $(GOFLAGS)
 GOTESTFLAGS := -v -race -covermode=atomic -coverprofile=coverage.out
 
 .PHONY: all
-all: build test ci_report checks # keep checks last as license test is brittle ...
-
-.PHONY: ci_report
+all: build test checks # keep checks last as license test is brittle ...
 
 .PHONY: build
 .PHONY: test

--- a/ecc_go/README.md
+++ b/ecc_go/README.md
@@ -80,8 +80,8 @@ Install ego by running the following:
 ```bash
 wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add
 add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
-wget https://github.com/edgelesssys/ego/releases/download/v1.4.1/ego_1.4.1_amd64_ubuntu-20.04.deb
-apt install ./ego_1.4.1_amd64_ubuntu-20.04.deb build-essential libssl-dev
+wget https://github.com/edgelesssys/ego/releases/download/v1.5.0/ego_1.5.0_amd64_ubuntu-22.04.deb
+apt install ./ego_1.5.0_amd64_ubuntu-22.04.deb build-essential libssl-dev
 ```
 
 You can find more information about ego installation on the official [documentation](https://docs.edgeless.systems/ego/#/getting-started/install).

--- a/protos/generate_protos.sh
+++ b/protos/generate_protos.sh
@@ -52,7 +52,7 @@ cat <<EOT > "${GO_BUILD_DIR}/staticcheck.conf"
 checks = ["-all"]
 EOT
 
-PROTOC_OPTS="--plugin=protoc-gen-nanopb=$NANOPB_PATH/generator/protoc-gen-nanopb-py2"
+PROTOC_OPTS="--plugin=protoc-gen-nanopb=$NANOPB_PATH/generator/protoc-gen-nanopb"
 
 # compile google protos
 $PROTOC_CMD "$PROTOC_OPTS" --proto_path=${PROTOS_DIR} --nanopb_out=$BUILD_DIR google/protobuf/*.proto

--- a/samples/demos/irb/chaincode/Makefile
+++ b/samples/demos/irb/chaincode/Makefile
@@ -38,7 +38,7 @@ PROTO_FILES := irb.proto
 .PHONY: protos
 protos: $(PROTO_BUILD_DIR)
 	$(PROTOC_CMD) \
-		--plugin=protoc-gen-nanopb=$(NANOPB_PATH)/generator/protoc-gen-nanopb-py2 \
+		--plugin=protoc-gen-nanopb=$(NANOPB_PATH)/generator/protoc-gen-nanopb \
 		--proto_path=$(PROTO_PATH) --nanopb_out=$(PROTO_BUILD_DIR) --nanopb_opt="-I${PROTO_PATH} -f ${PROTO_PATH}/irb.options" $(PROTO_FILES)
 
 $(PROTO_BUILD_DIR):

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -10,8 +10,8 @@
 #  - fpc image version:         FPC_VERSION
 #  - go version:                GO_VERSION
 #  - nanopb version:            NANOPB_VERSION
-#  - openssl version:           OPENSSL
-#  - sgxssl version:            SGXSSL
+#  - openssl version:           OPENSSL_VERSION
+#  - sgxssl version:            SGXSSL_VERSION
 #  - additional apt pkgs:       APT_ADD_PKGS
 
 
@@ -23,10 +23,10 @@ LABEL org.opencontainers.image.source https://github.com/hyperledger/fabric-priv
 # config/build params
 ARG GO_VERSION=1.21.9
 ARG NANOPB_VERSION=0.4.7
-ARG OPENSSL=1.1.1n
-ARG SGXSSL=2.16_1.1.1n
+ARG OPENSSL_VERSION=3.0.12
+ARG SGXSSL_VERSION=3.0_Rev1
 ARG APT_ADD_PKGS=
-ARG EGO_VERSION=1.4.1
+ARG EGO_VERSION=1.5.0
 
 # for convenience remember all versions as env variables ..
 ENV GO_VERSION=${GO_VERSION}
@@ -34,14 +34,12 @@ ENV NANOPB_VERSION=${NANOPB_VERSION}
 ENV OPENSSL_VERSION=${OPENSSL_VERSION}
 ENV SGXSSL_VERSION=${SGXSSL_VERSION}
 
+ENV DEBIAN_FRONTEND "noninteractive"
 
 WORKDIR /tmp
 
 RUN apt-get update -q \
-  && env DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
-  # above makes sure any install of 'tzdata' or alike (as e.g., pulled in via ubuntu 20.04) does not hang ...
-    apt-get install -y -q \
-    # build tools
+    && apt-get install -y -q \
     build-essential \
     clang-format \
     cmake \
@@ -51,9 +49,9 @@ RUN apt-get update -q \
     libssl-dev \
     libtool \
     pkg-config \
-    python \
+    python-is-python3 \
     protobuf-compiler \
-    python-protobuf \
+    python3-protobuf \
     psmisc \
     bc \
     software-properties-common \
@@ -64,9 +62,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && add-apt-repository "deb [arch="$(dpkg --print-architecture)"] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" \
   && apt-get update -q \
   && apt-get install -y -q \
-    # docker-ce \
     docker-ce-cli \
-    # containerd.io \
     docker-buildx-plugin \
     docker-compose-plugin
 
@@ -90,18 +86,17 @@ RUN go install golang.org/x/tools/cmd/goimports@latest \
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl
-RUN git clone 'https://github.com/intel/intel-sgx-ssl.git' \
-  && cd intel-sgx-ssl \
-  && . /opt/intel/sgxsdk/environment \
-  && git checkout lin_${SGXSSL} \
-  && cd openssl_source \
-  && wget -q https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz \
-  && cd ../Linux \
-  && make SGX_MODE=SIM NO_THREADS=1 SKIP_INTELCPU_CHECK=TRUE DESTDIR=${SGX_SSL} all test\
+RUN . /opt/intel/sgxsdk/environment \
+  && git clone --depth 1 --branch ${SGXSSL_VERSION} 'https://github.com/intel/intel-sgx-ssl.git' \
+  && wget -q -P /tmp/intel-sgx-ssl/openssl_source https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+  && cd /tmp/intel-sgx-ssl/Linux \
+  && make SGX_MODE=SIM NO_THREADS=1 SKIP_INTELCPU_CHECK=TRUE DESTDIR=${SGX_SSL} all \
   # Note: we need explicitly set to SIM as default is HW yet during docker
   # build you never have access to HW, regardless of platform. Note, though,
   # that libraries built work for both modes, on tests are executed for SIM only.
-  && make install
+  && make install \
+  && make clean \
+  && rm -rf /tmp/intel-sgx-ssl
 
 # Install nanopb
 ENV NANOPB_PATH=/usr/local/nanopb/
@@ -112,6 +107,6 @@ RUN git clone https://github.com/nanopb/nanopb.git ${NANOPB_PATH} \
   && make
 
 # Install ego
-RUN wget https://github.com/edgelesssys/ego/releases/download/v${EGO_VERSION}/ego_${EGO_VERSION}_amd64_ubuntu-20.04.deb \
-  && apt install -y -q ./ego_${EGO_VERSION}_amd64_ubuntu-20.04.deb \
-  && rm ego_${EGO_VERSION}_amd64_ubuntu-20.04.deb
+RUN wget https://github.com/edgelesssys/ego/releases/download/v${EGO_VERSION}/ego_${EGO_VERSION}_amd64_ubuntu-22.04.deb \
+  && apt install -y -q ./ego_${EGO_VERSION}_amd64_ubuntu-22.04.deb \
+  && rm ego_${EGO_VERSION}_amd64_ubuntu-22.04.deb

--- a/utils/docker/base-rt/Dockerfile
+++ b/utils/docker/base-rt/Dockerfile
@@ -14,8 +14,8 @@
 #  - additional apt pkgs:       APT_ADD_PKGS
 
 # config/build params (part 1)
-ARG UBUNTU_VERSION=20.04
-ARG UBUNTU_NAME=focal
+ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_NAME=jammy
 # NOTE:
 # - unfortunately, we do need both name (for repo) and version (for sgx directories), only docker image supports both ..
 #   18.04 <-> bionic, 20.04 <-> focal
@@ -30,7 +30,7 @@ ARG UBUNTU_VERSION
 ARG UBUNTU_NAME
 
 # config/build params (part 2)
-ARG SGX=2.16
+ARG SGX=2.22
 ARG PROTO_VERSION=22.3
 ARG APT_ADD_PKGS=
 
@@ -38,12 +38,11 @@ ARG APT_ADD_PKGS=
 # even when not all of them use go (or have it installed)
 ENV GOPATH=/project
 
+ENV DEBIAN_FRONTEND "noninteractive"
 
 # Get all necessary apt packages
 RUN apt-get update -q \
-  && env DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
-  # above makes sure any install of 'tzdata' or alike (as e.g., pulled in via ubuntu 20.04) does not hang ...
-  apt-get install -y -q\
+  && apt-get install -y -q \
     basez \
     ca-certificates \
     curl \
@@ -52,8 +51,8 @@ RUN apt-get update -q \
     wget \
     # jq need for e.g., external-builder
     jq \
+    build-essential \
     ${APT_ADD_PKGS} \
-  && apt-get -y -q upgrade \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -61,70 +60,49 @@ RUN apt-get update -q \
 RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${UBUNTU_NAME} main" >> /etc/apt/sources.list \
   && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
   && apt-get update -q \
-  && env DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
-    apt-get install -y -q \
+  && apt-get install -y -q \
     # We do not need daemons like AESMD as we run them on host (side-steps also
     # issues with config of /etc/aesmd.conf like proxy ..). Without this option
     # aesmd and lots of other plugsin are automatically pulled in. 
     # See SGX Installation notes and, in particular, linux/installer/docker/Dockerfile
     # in linux-sgx git repo of sdk/psw source. 
     --no-install-recommends \
-    # - dependencies
-    #   - PSW
-    libssl-dev \
-    libcurl4-openssl-dev \
-    libprotobuf-dev \
-    #   - SDK
-    #     Doc mentions 'build-essential' and 'python' but here
-    #     we need only shared libraries, build-essentials only in dev
-    #     and so omit them here to keep image small
-    #     Installation itself, though, needs make ..
-    make \
-    # - sgx packages
-    #   - runtime
-          libsgx-urts \
-    #     (also pulls in libsgx-enclave-common)
-    #   - basic architectural services, e.g., launch & attestation
-          # sgx-aesm-service (see above why commented out)
-    #   - launch service
-          libsgx-launch \
-    #   - algorithm agnostic attestation service (only need once moving to DCAP)
-    #      libsgx-quote-ex
+    libsgx-urts \
+    libsgx-uae-service \
     #   - EPID-based attestation service \
-          libsgx-epid
+    libsgx-epid \
     #   - DCAP-based attesation service
     #     libsgx-dcap* ...
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install SGX SDK
 # Note: not all descendents of this base image, e.g., ccenv, boilerplate and fpc-app, build sgx app.
 #   However, as simulation-mode libraries are only in the sdk and not in the psw packages, we need
 #   it already here and not only in the 'dev' image. 
-RUN mkdir -p /opt/intel
 WORKDIR /opt/intel
 RUN SGX_SDK_BIN_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX}/distro/ubuntu${UBUNTU_VERSION}-server \
-  && SGX_SDK_BIN_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BIN_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BIN_REPO}'/(sgx_linux_x64_sdk.*)|) { print "$1\n"; }') \
-  && wget -q ${SGX_SDK_BIN_REPO}/${SGX_SDK_BIN_FILE} \
-  && chmod +x ${SGX_SDK_BIN_FILE} \
-  && echo -e "no\n/opt/intel" | ./${SGX_SDK_BIN_FILE} \
-  && rm ${SGX_SDK_BIN_FILE}
+  && SGX_SDK_BIN_FILE=$(wget -P /tmp --delete-after --spider --recursive --level=1 --no-parent ${SGX_SDK_BIN_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BIN_REPO}'/(sgx_linux_x64_sdk.*)|) { print "$1\n"; }') \
+  && wget -q -P /tmp ${SGX_SDK_BIN_REPO}/${SGX_SDK_BIN_FILE} \
+  && chmod +x /tmp/${SGX_SDK_BIN_FILE} \
+  && echo -e "no\n/opt/intel" | /tmp/${SGX_SDK_BIN_FILE} \
+  && rm /tmp/${SGX_SDK_BIN_FILE}
+
 ENV SGX_SDK=/opt/intel/sgxsdk
 ENV PATH=${PATH}:${SGX_SDK}/bin:${SGX_SDK}/bin/x64
 ENV PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${SGX_SDK}/pkgconfig
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${SGX_SDK}/sdk_libs
 
 # LVI mitigations, needed to compile sgxssl, requires a
-#   recent version of binutils (>= 2.32). Ubuntu 18.04 only
-#   has 2.30 but Intel ships binary distro for 2.32.51.20190719
-#   As sgx ships tools also for 20.04, use these for simplicity 
-#   and uniformity reason
-RUN \
-     SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
-  && SGX_SDK_BINUTILS_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BINUTILS_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BINUTILS_REPO}'/(as.ld.objdump.*)|) { print "$1\n"; }') \
-  && wget -q ${SGX_SDK_BINUTILS_REPO}/${SGX_SDK_BINUTILS_FILE} \
+#   recent version of binutils (>= 2.32).
+WORKDIR /opt/intel
+RUN SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
+  && SGX_SDK_BINUTILS_FILE=$(wget -P /tmp --delete-after --spider --recursive --level=1 --no-parent ${SGX_SDK_BINUTILS_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BINUTILS_REPO}'/(as.ld.objdump.*)|) { print "$1\n"; }') \
+  && wget -q -P /tmp ${SGX_SDK_BINUTILS_REPO}/${SGX_SDK_BINUTILS_FILE} \
   && mkdir sgxsdk.extras \
   && cd sgxsdk.extras \
-  && tar -zxf ../${SGX_SDK_BINUTILS_FILE} \
-  && rm ../${SGX_SDK_BINUTILS_FILE} \
+  && tar -zxf /tmp/${SGX_SDK_BINUTILS_FILE} \
+  && rm /tmp/${SGX_SDK_BINUTILS_FILE} \
   && (cd /opt/intel/sgxsdk.extras/external/toolset/ && \
       for f in $(ls | grep -v ${UBUNTU_VERSION}); do rm -rf ${f}; done)
 # Note: above install file contains binutitls for _all_ supported distros


### PR DESCRIPTION
- Ubuntu 22.04
- SGX SDK 2.22
- SGX SSL 3.0_Rev1
- OpenSSL 3.0.12
- Ego 1.5.0
- Python 3