### PR TITLE
Use caching CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,8 @@
 #
 
 name: FPC test
-on: 
+on:
+  workflow_dispatch: 
   push:
     paths-ignore: 
       - '**.md'
@@ -60,16 +61,17 @@ jobs:
         run: |
           DOCKER_BUILD_OPTS="--build-arg UBUNTU_VERSION=${{ matrix.os-version }} --build-arg UBUNTU_NAME=${{ matrix.os-name }}" \
           make -C utils/docker pull pull-dev
-  
+
       - name: run make inside dev container
         env:
           DOCKER_DEV_CI_MODE: 1
           DOCKER_QUIET_BUILD: 1
-        run: |          
+        run: |
           DOCKER_BUILD_OPTS="--build-arg UBUNTU_VERSION=${{ matrix.os-version }} --build-arg UBUNTU_NAME=${{ matrix.os-name }}" \
           GOMODCACHE_PATH=$(go env GOMODCACHE) \
           make -C utils/docker run-dev DOCKER_DEV_OPTIONAL_CMD='env IS_CI_RUNNING=true \
                                                                 make all'
+
       #
       # continue only if we push to main and rebuild docker images
       #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -57,16 +60,16 @@ jobs:
         run: |
           DOCKER_BUILD_OPTS="--build-arg UBUNTU_VERSION=${{ matrix.os-version }} --build-arg UBUNTU_NAME=${{ matrix.os-name }}" \
           make -C utils/docker pull pull-dev
-
+  
       - name: run make inside dev container
         env:
           DOCKER_DEV_CI_MODE: 1
           DOCKER_QUIET_BUILD: 1
-        run: |
+        run: |          
           DOCKER_BUILD_OPTS="--build-arg UBUNTU_VERSION=${{ matrix.os-version }} --build-arg UBUNTU_NAME=${{ matrix.os-name }}" \
+          GOMODCACHE_PATH=$(go env GOMODCACHE) \
           make -C utils/docker run-dev DOCKER_DEV_OPTIONAL_CMD='env IS_CI_RUNNING=true \
                                                                 make all'
-
       #
       # continue only if we push to main and rebuild docker images
       #

--- a/config.mk
+++ b/config.mk
@@ -29,6 +29,9 @@ DOCKER_CMD := docker
 #   - DOCKER_BASE_RT_IMAGE_APT_ADD_PKGS (for all infrastructure containers)
 #   - DOCKER_BASE_DEV_IMAGE_APT_ADD_PKGS (for all images which build fabric/fpc code)
 #   - DOCKER_DEV_IMAGE_APT_ADD_PKGS (for dev image)
+# - You can mount your local go mod cache directory 
+#   to that of the docker image which allows caching of the dependencies and faster builds
+#   - GOMODCACHE_PATH (the path of your local go packages usually known by `go env GOMODCACHE`)
 
 
 # SGX related settings

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -78,11 +78,18 @@ endif
 # allows to override with `buildx build`
 DOCKER_BUILD_CMD ?= build
 
+# allows to mount host gomodcache into the container
+GOMODCACHE_PATH ?=
+DOCKER_GOMODCACHE=/project/pkg/mod
 
 # Docker run options
 # ------------------
 DOCKER_DEV_RUN_OPTS ?=
 DOCKER_DEV_RUN_OPTS += --rm
+# - mount local gomodcache from the host
+ifneq ($(GOMODCACHE_PATH),)
+	DOCKER_DEV_RUN_OPTS += -v "$(GOMODCACHE_PATH)":"$(DOCKER_GOMODCACHE)"
+endif
 # - import docker daemon socket (so dev container can run docker)
 DOCKER_DEV_RUN_OPTS += -v "$(DOCKER_DAEMON_SOCKET)":"$(DOCKER_SOCKET)"
 # - mount local fpc repo into the dev container so development inside container is


### PR DESCRIPTION
Fixes #753 
This PR activates caching on a directory on the runner and mounting it to the go location where dependencies are installed inside the container building the app