### PR TITLE
Restrict actions permission

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,8 @@ on:
 defaults:
   run:
     shell: bash
-permissions: {}
+permissions:
+  contents: read
 jobs:
   check-md-only:
     name: This job was triggered

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
      paths-ignore: 
        - '**.md'
        - '.github/workflows/**'
+
+permissions:
+  contents: read
+
 env:
   DOCKER_REGISTRY: 'ghcr.io'
   PUSH_TO_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This PR restricts the github workflows permission as recommended by OpenSSF as mentioned in issue #763 