### PR TITLE
Fix gh action permission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   DOCKER_REGISTRY: 'ghcr.io'


### PR DESCRIPTION
Recent commit 21455f27 restricted gh action permissions to read only, however, it needs package write permissions to update container images.
