### PR TITLE
Add fixup check to gh actions

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+name: Git checks
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
This PR introduces another github action to check if a PR contains fixup commits. The check does not prevent us from merging but highlights the needs of squashing before merging a PR.

I've created a test PR that contains this commit and an empty fixup commit. As shown in #775, the gh action indicates that there is a fixup commit.