### PR TITLE
Link to LFDT Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ Code of Conduct Guidelines
 ==========================
 
 Please review the Hyperledger [Code of
-Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct)
+Conduct](https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct.html#code-of-conduct)
 before participating. It is important that we keep things civil.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
The Hyperledger Wiki link is broken. LFDT is the new home of our code of conduct